### PR TITLE
Script for creating postgres table from csv file

### DIFF
--- a/csv_to_table.sql
+++ b/csv_to_table.sql
@@ -1,18 +1,21 @@
-/* This script is used to build the county_health table in postgres, using
+/* This script builds the county_health table in postgres, using
 the csv file available from tableau's public datasets (see link below)
 It performs the following steps:
-1. Create schema with provided name (e.g. test)
-2. Create table with name and data type for each column in CSV file below
-3. Copy data from csv file to table: Provide full path to file within single quotes below
+1. Create a schema with provided name (e.g. test)
+2. Create a table with name and data type for each column in CSV file below
+3. Copy data from csv file to postgres table: Provide full path to file within
+   single quotes
 
-Note: I've included the command needed to delete the table, which needs to be run if you wish
-to make changes to rebuild the table with updates to data model, etc
+Note: I've included the command needed to delete the table, which needs to be
+run if you wish to recreate the table with updates to data model, etc
 
-CSV source: https://public.tableau.com/s/sites/default/files/media/County_Health_Rankings.csv
+CSV link: 
+https://public.tableau.com/s/sites/default/files/media/County_Health_Rankings.csv
 */
 
 CREATE SCHEMA test
 
+--DROP TABLE IF EXISTS test.county_health
 CREATE TABLE test.county_health (
 	state varchar(2)
 	, county varchar
@@ -31,8 +34,5 @@ CREATE TABLE test.county_health (
 );
 
 COPY test.county_health
-FROM '/home/fdpearce/Documents/Projects/data/County_Health_Rankings/County_Health_Rankings.csv'
+FROM 'full_path_to_file.csv'
 DELIMITER ',' CSV HEADER;
-
---DROP TABLE IF EXISTS test.county_health
-

--- a/csv_to_table.sql
+++ b/csv_to_table.sql
@@ -1,0 +1,38 @@
+/* This script is used to build the county_health table in postgres, using
+the csv file available from tableau's public datasets (see link below)
+It performs the following steps:
+1. Create schema with provided name (e.g. test)
+2. Create table with name and data type for each column in CSV file below
+3. Copy data from csv file to table: Provide full path to file within single quotes below
+
+Note: I've included the command needed to delete the table, which needs to be run if you wish
+to make changes to rebuild the table with updates to data model, etc
+
+CSV source: https://public.tableau.com/s/sites/default/files/media/County_Health_Rankings.csv
+*/
+
+CREATE SCHEMA test
+
+CREATE TABLE test.county_health (
+	state varchar(2)
+	, county varchar
+	, state_code smallint
+	, county_code smallint
+	, year_span varchar(9)
+	, measure_name varchar
+	, measure_id smallint
+	, numerator numeric
+	, denominator numeric
+	, raw_value numeric 
+	, confidence_interval_lower numeric
+	, confidence_interval_upper numeric
+	, data_release_year smallint
+	, fips_code integer
+);
+
+COPY test.county_health
+FROM '/home/fdpearce/Documents/Projects/data/County_Health_Rankings/County_Health_Rankings.csv'
+DELIMITER ',' CSV HEADER;
+
+--DROP TABLE IF EXISTS test.county_health
+


### PR DESCRIPTION
This script was used to build the original table in postgres using the csv file downloaded from Tableau's collection of public datasets (see file for link).

I want to include a copy of this script in the repo, so that other users can reproduce the table in postgres on their own.

Issues:
- Maybe I should change the csv file path to something generic, so that other users will more easily recognize that they need to change the path?
- It would be easier for other users if this was written in Python instead of SQL, so that the script can be parameterized more easily (e.g. specify a schema name, table name, path to csv file, etc). What do you think?