### PR TITLE
updated exploratory_analysis.ipynb after deleting records with county…

### DIFF
--- a/exploratory_analysis.ipynb
+++ b/exploratory_analysis.ipynb
@@ -205,7 +205,90 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Illinois                90\n",
+       "Ohio                    90\n",
+       "Tennessee               90\n",
+       "California              90\n",
+       "Kansas                  90\n",
+       "Nevada                  90\n",
+       "Pennsylvania            90\n",
+       "Michigan                90\n",
+       "Maine                   90\n",
+       "New Hampshire           90\n",
+       "North Dakota            90\n",
+       "Rhode Island            90\n",
+       "Iowa                    90\n",
+       "Florida                 90\n",
+       "South Carolina          90\n",
+       "Wisconsin               90\n",
+       "Arkansas                90\n",
+       "Georgia                 90\n",
+       "Idaho                   90\n",
+       "Utah                    90\n",
+       "Mississippi             90\n",
+       "West Virginia           90\n",
+       "New Mexico              90\n",
+       "Oklahoma                90\n",
+       "Minnesota               90\n",
+       "Montana                 90\n",
+       "Arizona                 90\n",
+       "Oregon                  90\n",
+       "Massachusetts           90\n",
+       "Connecticut             90\n",
+       "Nebraska                90\n",
+       "Texas                   90\n",
+       "Alabama                 90\n",
+       "New Jersey              90\n",
+       "South Dakota            90\n",
+       "North Carolina          90\n",
+       "Indiana                 90\n",
+       "Virginia                90\n",
+       "Delaware                90\n",
+       "Wyoming                 90\n",
+       "Kentucky                90\n",
+       "Washington              90\n",
+       "New York                90\n",
+       "Louisiana               90\n",
+       "Missouri                90\n",
+       "Maryland                90\n",
+       "Vermont                 90\n",
+       "Colorado                90\n",
+       "District of Columbia    87\n",
+       "Alaska                  81\n",
+       "Hawaii                  81\n",
+       "Puerto Rico              1\n",
+       "Name: county, dtype: int64"
+      ]
+     },
+     "execution_count": 107,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Fred found out that county name are state names when county==0.\n",
+    "\n",
+    "df[df.county_code==0]['county'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df[df.county_code!=0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
@@ -242,68 +325,68 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>count</th>\n",
-       "      <td>273898.000000</td>\n",
-       "      <td>273898.000000</td>\n",
-       "      <td>273898.000000</td>\n",
-       "      <td>1.967560e+05</td>\n",
-       "      <td>1.774580e+05</td>\n",
-       "      <td>273898.000000</td>\n",
-       "      <td>273898.000000</td>\n",
-       "      <td>273898.000000</td>\n",
+       "      <td>269328.000000</td>\n",
+       "      <td>269328.000000</td>\n",
+       "      <td>269328.000000</td>\n",
+       "      <td>1.935450e+05</td>\n",
+       "      <td>1.744510e+05</td>\n",
+       "      <td>269328.000000</td>\n",
+       "      <td>269328.000000</td>\n",
+       "      <td>269328.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>mean</th>\n",
-       "      <td>30.363387</td>\n",
-       "      <td>101.741838</td>\n",
-       "      <td>38.637150</td>\n",
-       "      <td>7.729614e+03</td>\n",
-       "      <td>8.580908e+04</td>\n",
-       "      <td>1138.570435</td>\n",
-       "      <td>30465.128939</td>\n",
-       "      <td>2006.691119</td>\n",
+       "      <td>30.385459</td>\n",
+       "      <td>103.468210</td>\n",
+       "      <td>38.651217</td>\n",
+       "      <td>3.928770e+03</td>\n",
+       "      <td>4.364983e+04</td>\n",
+       "      <td>1139.766557</td>\n",
+       "      <td>30488.927575</td>\n",
+       "      <td>2006.692694</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>std</th>\n",
-       "      <td>15.156523</td>\n",
-       "      <td>108.012610</td>\n",
-       "      <td>37.451676</td>\n",
-       "      <td>7.387473e+04</td>\n",
-       "      <td>6.775931e+05</td>\n",
-       "      <td>2921.284656</td>\n",
-       "      <td>15174.872861</td>\n",
-       "      <td>3.153091</td>\n",
+       "      <td>15.146888</td>\n",
+       "      <td>108.102091</td>\n",
+       "      <td>37.463466</td>\n",
+       "      <td>2.100739e+04</td>\n",
+       "      <td>1.847151e+05</td>\n",
+       "      <td>2926.455025</td>\n",
+       "      <td>15165.404335</td>\n",
+       "      <td>3.152749</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>min</th>\n",
        "      <td>1.000000</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>1.000000</td>\n",
        "      <td>1.000000</td>\n",
        "      <td>0.000000e+00</td>\n",
        "      <td>1.000000e+01</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>1000.000000</td>\n",
+       "      <td>1001.000000</td>\n",
        "      <td>1997.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25%</th>\n",
        "      <td>19.000000</td>\n",
-       "      <td>33.000000</td>\n",
+       "      <td>35.000000</td>\n",
        "      <td>7.000000</td>\n",
-       "      <td>2.050000e+02</td>\n",
-       "      <td>2.056000e+03</td>\n",
-       "      <td>0.219000</td>\n",
-       "      <td>19000.000000</td>\n",
+       "      <td>2.000000e+02</td>\n",
+       "      <td>1.995000e+03</td>\n",
+       "      <td>0.220000</td>\n",
+       "      <td>19005.000000</td>\n",
        "      <td>2005.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>50%</th>\n",
        "      <td>29.000000</td>\n",
-       "      <td>77.000000</td>\n",
+       "      <td>79.000000</td>\n",
        "      <td>24.000000</td>\n",
-       "      <td>7.613200e+02</td>\n",
-       "      <td>8.155000e+03</td>\n",
-       "      <td>0.694000</td>\n",
-       "      <td>29179.000000</td>\n",
+       "      <td>7.330000e+02</td>\n",
+       "      <td>7.879000e+03</td>\n",
+       "      <td>0.693000</td>\n",
+       "      <td>29181.000000</td>\n",
        "      <td>2007.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -311,10 +394,10 @@
        "      <td>45.000000</td>\n",
        "      <td>133.000000</td>\n",
        "      <td>50.000000</td>\n",
-       "      <td>2.512812e+03</td>\n",
-       "      <td>2.735908e+04</td>\n",
-       "      <td>107.000000</td>\n",
-       "      <td>45079.000000</td>\n",
+       "      <td>2.348000e+03</td>\n",
+       "      <td>2.566700e+04</td>\n",
+       "      <td>106.700851</td>\n",
+       "      <td>45085.000000</td>\n",
        "      <td>2009.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -322,8 +405,8 @@
        "      <td>72.000000</td>\n",
        "      <td>840.000000</td>\n",
        "      <td>125.000000</td>\n",
-       "      <td>6.829725e+06</td>\n",
-       "      <td>3.769191e+07</td>\n",
+       "      <td>2.248384e+06</td>\n",
+       "      <td>1.000469e+07</td>\n",
        "      <td>32810.400000</td>\n",
        "      <td>72153.000000</td>\n",
        "      <td>2012.000000</td>\n",
@@ -334,27 +417,27 @@
       ],
       "text/plain": [
        "          state_code    county_code     measure_id     numerator  \\\n",
-       "count  273898.000000  273898.000000  273898.000000  1.967560e+05   \n",
-       "mean       30.363387     101.741838      38.637150  7.729614e+03   \n",
-       "std        15.156523     108.012610      37.451676  7.387473e+04   \n",
-       "min         1.000000       0.000000       1.000000  0.000000e+00   \n",
-       "25%        19.000000      33.000000       7.000000  2.050000e+02   \n",
-       "50%        29.000000      77.000000      24.000000  7.613200e+02   \n",
-       "75%        45.000000     133.000000      50.000000  2.512812e+03   \n",
-       "max        72.000000     840.000000     125.000000  6.829725e+06   \n",
+       "count  269328.000000  269328.000000  269328.000000  1.935450e+05   \n",
+       "mean       30.385459     103.468210      38.651217  3.928770e+03   \n",
+       "std        15.146888     108.102091      37.463466  2.100739e+04   \n",
+       "min         1.000000       1.000000       1.000000  0.000000e+00   \n",
+       "25%        19.000000      35.000000       7.000000  2.000000e+02   \n",
+       "50%        29.000000      79.000000      24.000000  7.330000e+02   \n",
+       "75%        45.000000     133.000000      50.000000  2.348000e+03   \n",
+       "max        72.000000     840.000000     125.000000  2.248384e+06   \n",
        "\n",
        "        denominator      raw_value      fips_code     start_year  \n",
-       "count  1.774580e+05  273898.000000  273898.000000  273898.000000  \n",
-       "mean   8.580908e+04    1138.570435   30465.128939    2006.691119  \n",
-       "std    6.775931e+05    2921.284656   15174.872861       3.153091  \n",
-       "min    1.000000e+01       0.000000    1000.000000    1997.000000  \n",
-       "25%    2.056000e+03       0.219000   19000.000000    2005.000000  \n",
-       "50%    8.155000e+03       0.694000   29179.000000    2007.000000  \n",
-       "75%    2.735908e+04     107.000000   45079.000000    2009.000000  \n",
-       "max    3.769191e+07   32810.400000   72153.000000    2012.000000  "
+       "count  1.744510e+05  269328.000000  269328.000000  269328.000000  \n",
+       "mean   4.364983e+04    1139.766557   30488.927575    2006.692694  \n",
+       "std    1.847151e+05    2926.455025   15165.404335       3.152749  \n",
+       "min    1.000000e+01       0.000000    1001.000000    1997.000000  \n",
+       "25%    1.995000e+03       0.220000   19005.000000    2005.000000  \n",
+       "50%    7.879000e+03       0.693000   29181.000000    2007.000000  \n",
+       "75%    2.566700e+04     106.700851   45085.000000    2009.000000  \n",
+       "max    1.000469e+07   32810.400000   72153.000000    2012.000000  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -365,35 +448,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "numerator     -0.036932\n",
-       "denominator    0.108359\n",
-       "raw_value      1.000000\n",
-       "Name: raw_value, dtype: float64"
+       "state               0\n",
+       "county              0\n",
+       "state_code          0\n",
+       "county_code         0\n",
+       "measure_name        0\n",
+       "measure_id          0\n",
+       "raw_value           0\n",
+       "fips_code           0\n",
+       "start_year          0\n",
+       "numerator       75783\n",
+       "denominator     94877\n",
+       "dtype: int64"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df[['numerator', 'denominator', 'raw_value']].corr()['raw_value']"
+    "df.isnull().sum().sort_values()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAASPUlEQVR4nO3df6zdd13H8eeLwh1mYAVaDOkPW7zNYkMMsJsOoyFLBO3ASxGJaflDNMsaojX4hwklGIE/jMOoCYQJVmgGBFcmTmxdySDoUkwW1g4HrKuTUkd26UKH0wrGOAdv/7hn43i5t5xzv+ec77n3+3wkJz3nc8/5ft/33e89930/5/39fFNVSJIkSV32jLYDkCRJktpmUSxJkqTOsyiWJElS51kUS5IkqfMsiiVJktR5FsWSJEnqvGe2HQDApk2baseOHW2HIUmSpHXuvvvu+1ZVbV46PhVF8Y4dOzhz5kzbYUiSJGmdS/L15cZtn5AkSVLntVoUJ5lPcuTy5ctthiFJkqSOa7UorqoTVXVw48aNbYYhSZKkjrN9QpIkSZ1nUSxJkqTOm4rVJ9qy4/Cd/+/xwze/tqVIJEmS1CZPtJMkSVLneaKdJEmSOs+eYkmSJHWeRbEkSZI6z6JYkiRJnTfyojjJ9Uk+n+SDSa4f9fYlSZKkURuoKE5yNMmlJA8sGd+b5KEk55Mc7g0X8B3g2cDCaMOVJEmSRm/QmeJbgb39A0k2ALcANwC7gQNJdgOfr6obgLcB7x5dqJIkSdJ4DFQUV9Up4PElw3uA81V1oaqeAI4B+6rqe72v/ztw1UrbTHIwyZkkZx577LFVhC5JkiSNRpOe4i3AI32PF4AtSd6Q5M+BjwHvX+nFVXWkquaqam7z5s0NwpAkSZKaaXKZ5ywzVlV1B3DHQBtI5oH52dnZBmFIkiRJzTSZKV4AtvU93gpcbBaOJEmSNHlNiuLTwK4kO5PMAPuB48NswMs8S5IkaRoMuiTbbcA9wDVJFpLcWFVPAoeAu4BzwO1VdXaYnSeZT3Lk8uXLw8YtSZIkjcxAPcVVdWCF8ZPAyZFGJEmSJE1Yq5d5tn1CkiRJ06DVoliSJEmaBq0WxfYUS5IkaRrYPiFJkqTOc6ZYkiRJnedMsSRJkjrPE+0kSZLUeRbFkiRJ6jx7iiVJktR59hRLkiSp82yfkCRJUudZFEuSJKnzLIolSZLUeZ5oJ0mSpM7zRDtJkiR1nu0TkiRJ6jyLYkmSJHWeRbEkSZI675nj2GiSq4FTwDur6u/GsY9x2HH4zqfvP3zza1uMRJIkSZM00ExxkqNJLiV5YMn43iQPJTmf5HDfl94G3D7KQCVJkqRxGbR94lZgb/9Akg3ALcANwG7gQJLdSV4FPAh8c4RxSpIkSWMzUPtEVZ1KsmPJ8B7gfFVdAEhyDNgHPAe4msVC+b+TnKyq7y3dZpKDwEGA7du3rzZ+SZIkqbEmPcVbgEf6Hi8A11XVIYAkvw58a7mCGKCqjiR5FJifmZm5tkEckiRJUiNNVp/IMmP19J2qW3/YSXZevEOSJEnToElRvABs63u8Fbg4zAa8zLMkSZKmQZOi+DSwK8nOJDPAfuD4aMKSJEmSJmfQJdluA+4BrkmykOTGqnoSOATcBZwDbq+qs8Ps3PYJSZIkTYNBV584sML4SeDkaneeZB6Yn52dXe0mJEmSpMbGckW7QVXVCeDE3NzcTW3GsRyvbidJktQdTXqKJUmSpHWh1aLY1SckSZI0DVotij3RTpIkSdPAmWJJkiR1njPFkiRJ6jxPtJMkSVLnWRRLkiSp8+wpliRJUud58Y4BeCEPSZKk9c32CUmSJHWeRbEkSZI6z6JYkiRJneeJdpIkSeo8L94hSZKkzrN9QpIkSZ1nUSxJkqTOG/k6xUl+CngrsAn4XFV9YNT7aJNrFkuSJK0/A80UJzma5FKSB5aM703yUJLzSQ4DVNW5qnoL8KvA3OhDliRJkkZr0PaJW4G9/QNJNgC3ADcAu4EDSXb3vvY64B+Bz40sUmnK7Dh859M3SZK0tg3UPlFVp5LsWDK8BzhfVRcAkhwD9gEPVtVx4HiSO4G/HF240vAmUbQOsg/bbSRJml5Neoq3AI/0PV4ArktyPfAG4Crg5EovTnIQOAiwffv2BmFIi6Z9xtZ+dEmSpleTojjLjFVV3Q3c/cNeXFVHkjwKzM/MzFzbIA512LQXwitZKW6LZUmS2tGkKF4AtvU93gpcHGYDVXUCODE3N3dTgzjUMWu1EB7ESrPJzjJLkjReTYri08CuJDuBbwD7gTcNs4Ek88D87OxsgzCk9Wml4t8CWZKk0RuoKE5yG3A9sCnJAvDOqvpwkkPAXcAG4GhVnR1bpOqc9TwjPCoWyJIkjUaqqu0YmJubqzNnzkx8v6MsuixIRsNCeDRsvZAkaXlJ7quqH7iWxsivaDcM2yek8fCPC0mShtNqUeyJdgILuEly1liSpOU5Uyx1lMvCSZL0fc4UqxXODkuSpGnSalEsafp4yWpJUhfZPiFpaPYmS5LWG9snNDG2TEiSpGll+4SkRpb+sePMsSRpLbJ9YkT8OHl5zg53j6taSJLWome0ufOqOlFVBzdu3NhmGJIkSeo42yc0cs4Oazl+miJJmmYWxZImzhYLSdK0sSjWSDg7LEmS1jJPtBsDPyaWJElaW1ynWKvm7LBGzT8oJUltsX1C0lSy71iSNEmtLskmSZIkTQNnijUUWyYkSdJ6NJaiOMnrgdcCLwRuqarPjGM/krrHvmNJ0jgMXBQnOQr8EnCpql7SN74XeC+wAfhQVd1cVZ8CPpXkecAfAxbFksbKYlmS1MQwM8W3Au8HPvrUQJINwC3Aq4EF4HSS41X1YO8pv9f7emf5i1oan5Xaefy5kyQNa+AT7arqFPD4kuE9wPmqulBVTwDHgH1Z9B7g01X1xdGFK0mSJI1e057iLcAjfY8XgOuA3wZeBWxMMltVH1z6wiQHgYMA27dvbxiGJC3PWWNJ0iCaFsVZZqyq6n3A+670wqo6kuRRYH5mZubahnFIkiRJq9Z0neIFYFvf463AxYbblCRJkiaq6UzxaWBXkp3AN4D9wJsGfbGXeZbUFtsqJEn9hlmS7TbgemBTkgXgnVX14SSHgLtYXJLtaFWdHWKb88D87OzscFFL0ip48RlJ0kpSVW3HwNzcXJ05c2bi+530L8i1OhtlIaEuWas/p5KkwSS5r6rmlo63epnnrs0U+3GtNP38OZWkbmq1KLaneDo5MywtskCWpO5ouvpEI0nmkxy5fPlym2FIkiSp45wpFuDssCRJ6rZWi2JJWitspZCk9c0T7SRpSBbIkrT+2D4hSQ1YIEvS+tDqiXaSJEnSNLB9oiXOLkmSJE0P2yckqUX+gSxJ08HVJzrMZdgkSZIWWRRL0hhc6Y/OlWaEnTWWpPZ4op0kSZI6zxPtJGlEbEmSpLXLE+0kacKGLZ5tq5Ck8bN9QpIkSZ1nUSxJkqTOc/WJKeZHppJWw/cOSRreyIviJC8G3gFsrKo3jnr7650n6kiCwd4LLH4laXQGKoqTHAV+CbhUVS/pG98LvBfYAHyoqm6uqgvAjUk+OY6Au6rJLz8LbUmSpCsbdKb4VuD9wEefGkiyAbgFeDWwAJxOcryqHhx1kJKkK/OPX0lqZqAT7arqFPD4kuE9wPmqulBVTwDHgH0jjk+SJEkauyY9xVuAR/oeLwDXJXkB8AfAy5K8var+cLkXJzkIHATYvn17gzD0FPsLJS3l+4IkDaZJUZxlxqqq/g14yw97cVUdSfIoMD8zM3NtgzjWPD/2lDQo3y8kaTyaFMULwLa+x1uBi83CkSRNi5UKcGecJa1HTS7ecRrYlWRnkhlgP3B8mA1U1YmqOrhx48YGYUiSJEnNDFQUJ7kNuAe4JslCkhur6kngEHAXcA64varODrPzJPNJjly+fHnYuCVJkqSRGah9oqoOrDB+Eji52p1X1QngxNzc3E2r3YYkSZLUVKuXeU4yD8zPzs62GYYkaQRc6ULSWtakp7gxe4olSZI0DZwpXoMGWZLJZZskLTXI+8KoZnibzho76yxp0pwpliRJUue1WhRLkiRJ08D2CUlSa8bRJjHsNld6vi0cUrfYPiFJkqTOs31CkiRJnWf7hCTpacOubjNse0JTK21rGtobJt1uMao2EUmLbJ+QJElS59k+IUmSpM6zKJYkSVLnWRRLkiSp8zzRTpK0apM4iW4c21/pRLNxnGg4qtdO0z6mQVe+z3Ewd8vzRDtJkiR1nu0TkiRJ6jyLYkmSJHWeRbEkSZI6b+Qn2iW5Gvgz4Ang7qr6+Kj3IUmSJI3SQDPFSY4muZTkgSXje5M8lOR8ksO94TcAn6yqm4DXjTheSZIkaeQGbZ+4FdjbP5BkA3ALcAOwGziQZDewFXik97TvjiZMSZIkaXwGap+oqlNJdiwZ3gOcr6oLAEmOAfuABRYL4/u5QtGd5CBwEGD79u3Dxi1J6ogm6xdPcu3jYfe79Dn968WOKu5htzPs8weJeaXnrOb7bbK+9KjW4x12jd/1vCbwestFkxPttvD9GWFYLIa3AHcAv5LkA8CJlV5cVUeqaq6q5jZv3twgDEmSJKmZJifaZZmxqqr/An5joA14RTtJkiRNgSYzxQvAtr7HW4GLzcKRJEmSJq9JUXwa2JVkZ5IZYD9wfJgNeJlnSZIkTYNBl2S7DbgHuCbJQpIbq+pJ4BBwF3AOuL2qzg6z8yTzSY5cvnx52LglSZKkkRl09YkDK4yfBE6ududVdQI4MTc3d9NqtyFJkiQ11eplnp0pliRJ0jRIVbUdA0keA77ewq43Ad9qYb9dZs4nz5xPnjmfPHM+WeZ78sz56PxEVf3AesBTURS3JcmZqpprO44uMeeTZ84nz5xPnjmfLPM9eeZ8/Fptn5AkSZKmgUWxJEmSOq/rRfGRtgPoIHM+eeZ88sz55JnzyTLfk2fOx6zTPcWSJEkSOFMsSZIkdbcoTrI3yUNJzic53HY8a1mSh5N8Jcn9Sc70xp6f5LNJvtr793l9z397L+8PJfnFvvFre9s5n+R9SdLG9zONkhxNcinJA31jI8txkquSfKI3/oUkOyb5/U2jFXL+riTf6B3r9yd5Td/XzHkDSbYl+Yck55KcTfLW3rjH+ZhcIece52OS5NlJ7k3ypV7O390b9zifBlXVuRuwAfga8GJgBvgSsLvtuNbqDXgY2LRk7I+Aw737h4H39O7v7uX7KmBn7/9hQ+9r9wI/AwT4NHBD29/btNyAVwIvBx4YR46B3wQ+2Lu/H/hE299z27cVcv4u4HeXea45b57vFwEv791/LvAvvbx6nE8+5x7n48t5gOf07j8L+ALwCo/z6bh1daZ4D3C+qi5U1RPAMWBfyzGtN/uAj/TufwR4fd/4sar6n6r6V+A8sCfJi4Afrap7avEn+aN9r+m8qjoFPL5keJQ57t/WJ4Gf7/pM/Qo5X4k5b6iqHq2qL/bufxs4B2zB43xsrpDzlZjzhmrRd3oPn9W7FR7nU6GrRfEW4JG+xwtc+Y1AV1bAZ5Lcl+Rgb+zHq+pRWHzjBV7YG18p91t695eOa2WjzPHTr6mqJ4HLwAvGFvnadijJl3vtFU99xGnOR6j3ce/LWJxF8zifgCU5B4/zsUmyIcn9wCXgs1XlcT4luloUL/cXk8twrN7PVtXLgRuA30ryyis8d6Xc+38yOqvJsfkfzAeAnwReCjwK/Elv3JyPSJLnAH8N/E5V/eeVnrrMmDlfhWVy7nE+RlX13ap6KbCVxVnfl1zh6eZ8grpaFC8A2/oebwUuthTLmldVF3v/XgL+hsX2lG/2Pt6h9++l3tNXyv1C7/7Sca1slDl++jVJnglsZPDWgc6oqm/2fqF9D/gLFo91MOcjkeRZLBZnH6+qO3rDHudjtFzOPc4no6r+A7gb2IvH+VToalF8GtiVZGeSGRYb0Y+3HNOalOTqJM996j7wC8ADLObzzb2nvRn4297948D+3tmxO4FdwL29j4u+neQVvd6nX+t7jZY3yhz3b+uNwN/3+tTU56lfWj2/zOKxDua8sV5+Pgycq6o/7fuSx/mYrJRzj/PxSbI5yY/17v8I8Crgn/E4nw5tn+nX1g14DYtn2n4NeEfb8azVG4sreHypdzv7VC5Z7F/6HPDV3r/P73vNO3p5f4i+FSaAORbffL8GvJ/exWW8FcBtLH6M+b8szgLcOMocA88G/orFkzjuBV7c9vfc9m2FnH8M+ArwZRZ/8bzInI8s3z/H4ke8Xwbu791e43HeSs49zseX858G/qmX2weA3++Ne5xPwc0r2kmSJKnzuto+IUmSJD3NoliSJEmdZ1EsSZKkzrMoliRJUudZFEuSJKnzLIolSZLUeRbFkiRJ6jyLYkmSJHXe/wF6YOBG6SOJrQAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAASW0lEQVR4nO3df6zdd13H8eeLwh1mYPmxYUh/2GKbxWYxwG46jIYsEaSDXYpIYssfollWUWv0DxNGMAp/GIdRk5FNlgLNwOjKnIhtKBkEXYbJwnqLA9bVSakju7Shw+kVjHEO3v5xz8bxck85t99zzvfc+30+kpOe87nnfL/v8+733vu+n/P+fr6pKiRJkqQue07bAUiSJEltsyiWJElS51kUS5IkqfMsiiVJktR5FsWSJEnqPItiSZIkdd5z2w4A4Iorrqht27a1HYYkSZLWuZMnT36rqq5cPj4VRfG2bduYn59vOwxJkiStc0m+vtK47ROSJEnqvFaL4iRzSQ4tLi62GYYkSZI6rtWiuKqOVdWBjRs3thmGJEmSOs72CUmSJHWeRbEkSZI6bypWn2jLtps/9f8eP3bLm1qKRJIkSW3yRDtJkiR1nifaSZIkqfPsKZYkSVLnWRRLkiSp8yyKJUmS1HkjL4qTXJfk80nuSHLdqLcvSZIkjdpQRXGSw0kuJHl42fieJI8mOZPk5t5wAd8Bng8sjDZcSZIkafSGnSm+E9jTP5BkA3A7cD2wC9ifZBfw+aq6HngX8L7RhSpJkiSNx1BFcVXdDzy5bHg3cKaqzlbVU8ARYG9Vfa/39X8HLhu0zSQHkswnmX/iiScuIXRJkiRpNJpc0W4T8Hjf4wXg2iRvBd4AvAi4bdCLq+pQkvPA3MzMzDUN4pAkSZIaaXKiXVYYq6r6RFX9WlX9UlXdd7ENePEOSZIkTYMmRfECsKXv8Wbg3Go24GWeJUmSNA2aFMUngJ1JtieZAfYBR0cTliRJkjQ5wy7JdhfwAHBVkoUkN1bV08BB4F7gNHB3VZ1azc5tn5AkSdI0GOpEu6raP2D8OHD8UneeZA6Y27Fjx6VuQpIkSWqs1cs8O1MsSZKkadBqUSxJkiRNg1aLYlefkCRJ0jSwfUKSJEmd50yxJEmSOs+ZYkmSJHWeJ9pJkiSp8yyKJUmS1Hn2FEuSJKnz7CmWJElS59k+IUmSpM6zKJYkSVLnWRRLkiSp8zzRTpIkSZ3niXaSJEnqPNsnJEmS1HkWxZIkSeq8sRTFSS5PcjLJDePYviRJkjRKzx3mSUkOAzcAF6rq6r7xPcCtwAbgw1V1S+9L7wLuHnGsY7ft5k89e/+xW97UYiSSJEmapGFniu8E9vQPJNkA3A5cD+wC9ifZleR1wCPAN0cYpyRJkjQ2Q80UV9X9SbYtG94NnKmqswBJjgB7gRcAl7NUKP93kuNV9b2RRSxJkiSN2FBF8QCbgMf7Hi8A11bVQYAkvwJ8a1BBnOQAcABg69atDcKQJEmSmmlSFGeFsXr2TtWdF3txVR1Kch6Ym5mZuaZBHJIkSVIjTVafWAC29D3eDJxbzQa8eIckSZKmQZOi+ASwM8n2JDPAPuDoajbgZZ4lSZI0DYYqipPcBTwAXJVkIcmNVfU0cBC4FzgN3F1Vp8YXqiRJkjQew64+sX/A+HHg+KXuvKqOAcdmZ2dvutRtSJIkSU21epln2yckSZI0DZqsPtHYNM8Ue3U7SZKk7nCmWJIkSZ3XalHskmySJEmaBq0WxZIkSdI0sH1CkiRJnWf7hCRJkjrP9glJkiR1nkWxJEmSOs+eYkmSJHWeF+8YghfykCRJWt9sn5AkSVLnWRRLkiSp8+wpliRJUue5TrEkSZI6z/YJSZIkdZ5FsSRJkjrPoliSJEmdN/KiOMlPJrkjyT1Jfn3U25ckSZJGbaiLdyQ5DNwAXKiqq/vG9wC3AhuAD1fVLVV1GnhnkucAHxpDzK3yQh6SJEnrz7AzxXcCe/oHkmwAbgeuB3YB+5Ps6n3tzcA/Ap8bWaSSJEnSmAw1U1xV9yfZtmx4N3Cmqs4CJDkC7AUeqaqjwNEknwL+anThSs30z/RPmp8sSJI0vYYqigfYBDze93gBuDbJdcBbgcuA44NenOQAcABg69atDcKQflCbxe8gtt5IkjS9mhTFWWGsquo+4L4f9uKqOpTkPDA3MzNzTYM4JGA6C+FBLJAlSZouTYriBWBL3+PNwLnVbKCqjgHHZmdnb2oQhzpmLRW/wxj0fiyWJUmanCZF8QlgZ5LtwDeAfcDbV7OBJHPA3I4dOxqEIa1PFsuSJE3OsEuy3QVcB1yRZAH4g6r6SJKDwL0sLcl2uKpOjS1Sdc56mxEeFYtlSZJGL1XVdgzMzs7W/Pz8xPc7yqLLgmQ0LIRHo/94tH9ZkqTvS3KyqmaXjzdpn2jM9glpPPzjQpKk1Wm1KPZEO2mynDWWJGllzhSrdc5qtsPeZEmSvs+ZYrXCQliSJE2TVotiSdNnmD9YnE2WJK03tk9IWjV7kyVJ643tE5oYWyYkSdK0sn1CUiPL/9hx5liStBbZPjEifpy8MmeHu8dVLSRJa9Fz2tx5VR2rqgMbN25sMwxJkiR1nO0TGjlnh7USP02RJE0zi2JJE2eLhSRp2lgUayScHZYkSWtZqz3FSeaSHFpcXGwzDEmSJHVcqqrtGJidna35+fmJ73cSs5vr+eNgZ4c1Tv3fO/YjS5JGJcnJqppdPm77hKSp5B9dkqRJarV9QpIkSZoGzhRrVZy9kyRJ69FYiuIkbwHeBLwMuL2qPjOO/UjqHvuLJUnjMHRRnOQwcANwoaqu7hvfA9wKbAA+XFW3VNUngU8meTHwJ4BFsaSxsliWJDWxmpniO4HbgI89M5BkA3A78HpgATiR5GhVPdJ7yu/1vt5Z/qKWxmdQO4/fd5Kk1Rr6RLuquh94ctnwbuBMVZ2tqqeAI8DeLHk/8Omq+uLowpUkSZJGr2lP8Sbg8b7HC8C1wG8BrwM2JtlRVXcsf2GSA8ABgK1btzYMQ5JW5qyxJGkYTYvirDBWVfUB4AMXe2FVHUpyHpibmZm5pmEckiRJ0iVruk7xArCl7/Fm4FzDbUqSJEkT1XSm+ASwM8l24BvAPuDtw764qo4Bx2ZnZ29qGIck/VCDTsyzrUKSNPRMcZK7gAeAq5IsJLmxqp4GDgL3AqeBu6vq1Cq2OZfk0OLi4mrjliRJkkYmVdV2DMzOztb8/PzE9zvpq7Ot1dkor2Knrlqr37OSpMGSnKyq2eXjrV7mOckcMLdjx442w5iYtXIWvEWwJEnqmlaLYnuKJU2ztfKHrCSpuaarTzRiT7EkSZKmgTPFAmyZkCRJ3dZqUSxJa4WtFJK0vnminSStkgWyJK0/tk9IUgMWyJK0Ptg+0RJ/kUqSJE0PV5+QJElS59k+IUkt8lMjSZoOtk90mMuwSeOz/PvLgleSpptFsSRNwDAzws4aS1J7Wu0pliRJkqaB6xRL0ojYkiRJa5cn2knShK22eLatQpLGz/YJSZIkdZ5FsSRJkjrP1SemzKCPVf3IVNJyg9oqbLeQpNUbeVGc5BXAe4CNVfW2UW9fkrrAk/YkabKGKoqTHAZuAC5U1dV943uAW4ENwIer6paqOgvcmOSecQTcVU1mfvzlKkmSdHHDzhTfCdwGfOyZgSQbgNuB1wMLwIkkR6vqkVEHKUm6OP/4laRmhjrRrqruB55cNrwbOFNVZ6vqKeAIsHfE8UmSJElj16SneBPweN/jBeDaJC8F/hB4VZJ3V9UfrfTiJAeAAwBbt25tEIae4ck1kpbz54IkDadJUZwVxqqq/g145w97cVUdSnIemJuZmbmmQRxrnh97ShqWPy8kaTyaFMULwJa+x5uBc83CkSRNC5eIlNQlTS7ecQLYmWR7khlgH3B0NRuoqmNVdWDjxo0NwpAkSZKaGaooTnIX8ABwVZKFJDdW1dPAQeBe4DRwd1WdWs3Ok8wlObS4uLjauCVJkqSRGap9oqr2Dxg/Dhy/1J1X1THg2Ozs7E2Xug1JkiSpqVYv85xkDpjbsWNHm2FIkkbAlS4krWVNeoobs6dYkiRJ08CZ4jVomCWZXLZJ0nLD/FwY1Qxv01ljZ50lTZozxZIkSeq8VotiSZIkaRrYPiFJas042iRWu81Bz7eFQ+oW2yckSZLUebZPSJIkqfNsn5AkPWu1q9ustj2hqUHbmob2hkm3W4yqTUTSEtsnJEmS1Hm2T0iSJKnzLIolSZLUeRbFkiRJ6jxPtJMkXbJJnEQ3ju0POtFsHCcajuq107SPadCV9zkO5m5lnmgnSZKkzrN9QpIkSZ1nUSxJkqTOsyiWJElS5438RLsklwN/DjwF3FdVfznqfUiSJEmjNNRMcZLDSS4keXjZ+J4kjyY5k+Tm3vBbgXuq6ibgzSOOV5IkSRq5Ydsn7gT29A8k2QDcDlwP7AL2J9kFbAYe7z3tu6MJU5IkSRqfodonqur+JNuWDe8GzlTVWYAkR4C9wAJLhfFDXKToTnIAOACwdevW1cYtSeqIJusXT3Lt49Xud/lz+teLHVXcq93Oap8/TMyDnnMp77fJ+tKjWo93tWv8ruc1gddbLpqcaLeJ788Iw1IxvAn4BPCLST4IHBv04qo6VFWzVTV75ZVXNghDkiRJaqbJiXZZYayq6r+AXx1qA17RTpIkSVOgyUzxArCl7/Fm4FyzcCRJkqTJa1IUnwB2JtmeZAbYBxxdzQa8zLMkSZKmwbBLst0FPABclWQhyY1V9TRwELgXOA3cXVWnVrPzJHNJDi0uLq42bkmSJGlkhl19Yv+A8ePA8UvdeVUdA47Nzs7edKnbkCRJkppq9TLPzhRLkiRpGqSq2o6BJE8AX29h11cA32phv11mzifPnE+eOZ88cz5Z5nvyzPno/HhV/cB6wFNRFLclyXxVzbYdR5eY88kz55NnzifPnE+W+Z48cz5+rbZPSJIkSdPAoliSJEmd1/Wi+FDbAXSQOZ88cz555nzyzPlkme/JM+dj1umeYkmSJAmcKZYkSZK6WxQn2ZPk0SRnktzcdjxrWZLHknwlyUNJ5ntjL0ny2SRf7f374r7nv7uX90eTvKFv/Jreds4k+UCStPF+plGSw0kuJHm4b2xkOU5yWZKP98a/kGTbJN/fNBqQ8/cm+UbvWH8oyRv7vmbOG0iyJck/JDmd5FSS3+6Ne5yPyUVy7nE+Jkmen+TBJF/q5fx9vXGP82lQVZ27ARuArwGvAGaALwG72o5rrd6Ax4Arlo39MXBz7/7NwPt793f18n0ZsL33/7Ch97UHgZ8GAnwauL7t9zYtN+C1wKuBh8eRY+A3gDt69/cBH2/7Pbd9G5Dz9wK/u8JzzXnzfL8ceHXv/guBf+nl1eN88jn3OB9fzgO8oHf/ecAXgNd4nE/HraszxbuBM1V1tqqeAo4Ae1uOab3ZC3y0d/+jwFv6xo9U1f9U1b8CZ4DdSV4O/GhVPVBL38kf63tN51XV/cCTy4ZHmeP+bd0D/FzXZ+oH5HwQc95QVZ2vqi/27n8bOA1swuN8bC6S80HMeUO15Du9h8/r3QqP86nQ1aJ4E/B43+MFLv6DQBdXwGeSnExyoDf2Y1V1HpZ+8AIv640Pyv2m3v3l4xpslDl+9jVV9TSwCLx0bJGvbQeTfLnXXvHMR5zmfIR6H/e+iqVZNI/zCViWc/A4H5skG5I8BFwAPltVHudToqtF8Up/MbkMx6X7map6NXA98JtJXnuR5w7Kvf8no3MpOTb/w/kg8BPAK4HzwJ/2xs35iCR5AfA3wO9U1X9e7KkrjJnzS7BCzj3Ox6iqvltVrwQ2szTre/VFnm7OJ6irRfECsKXv8WbgXEuxrHlVda737wXgb1lqT/lm7+Mdev9e6D19UO4XeveXj2uwUeb42dckeS6wkeFbBzqjqr7Z+4X2PeBDLB3rYM5HIsnzWCrO/rKqPtEb9jgfo5Vy7nE+GVX1H8B9wB48zqdCV4viE8DOJNuTzLDUiH605ZjWpCSXJ3nhM/eBnwceZimf7+g97R3A3/XuHwX29c6O3Q7sBB7sfVz07SSv6fU+/XLfa7SyUea4f1tvA/6+16emPs/80ur5BZaOdTDnjfXy8xHgdFX9Wd+XPM7HZFDOPc7HJ8mVSV7Uu/8jwOuAf8bjfDq0faZfWzfgjSydafs14D1tx7NWbyyt4PGl3u3UM7lkqX/pc8BXe/++pO817+nl/VH6VpgAZln64fs14DZ6F5fxVgB3sfQx5v+yNAtw4yhzDDwf+GuWTuJ4EHhF2++57duAnP8F8BXgyyz94nm5OR9Zvn+WpY94vww81Lu90eO8lZx7nI8v5z8F/FMvtw8Dv98b9zifgptXtJMkSVLndbV9QpIkSXqWRbEkSZI6z6JYkiRJnWdRLEmSpM6zKJYkSVLnWRRLkiSp8yyKJUmS1HkWxZIkSeq8/wOfa+w9jeONNwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -413,32 +504,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2008.0    37633\n",
-       "2009.0    34590\n",
-       "2010.0    31600\n",
-       "2006.0    30550\n",
-       "2007.0    25181\n",
-       "2004.0    21912\n",
-       "2005.0    21901\n",
-       "2011.0    21800\n",
-       "2003.0    21539\n",
-       "2002.0     9298\n",
-       "2012.0     3270\n",
-       "1997.0     2935\n",
-       "1998.0     2930\n",
-       "2001.0     2921\n",
-       "2000.0     2919\n",
-       "1999.0     2919\n",
+       "2008.0    37024\n",
+       "2009.0    34033\n",
+       "2010.0    31092\n",
+       "2006.0    29991\n",
+       "2007.0    24775\n",
+       "2004.0    21557\n",
+       "2005.0    21546\n",
+       "2011.0    21445\n",
+       "2003.0    21133\n",
+       "2002.0     9145\n",
+       "2012.0     3218\n",
+       "1997.0     2884\n",
+       "1998.0     2879\n",
+       "2001.0     2870\n",
+       "2000.0     2868\n",
+       "1999.0     2868\n",
        "Name: start_year, dtype: int64"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -449,12 +540,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQn0lEQVR4nO3df6hl51kv8O/jxKlQdVATL2WScVJPKHfwD20P8SdS8Nek9RivVzRzBX8QMlRvRP8QHFHQP6ugYDFaRhuiIom1eq8ZOhJFbwkXis1Eak0aYqcxkmNC01oYRcRaffzj7KS7xznjPmftc9Y+Z30+sDl7v2evtd49z3nPeeZdz3pXdXcAAGDKPmfsDgAAwNgkxQAATJ6kGACAyZMUAwAweZJiAAAmT1IMAMDk3TR2B5Lk5ptv7tOnT4/dDQAAjrgnn3zyE919y/b2lUiKT58+nStXrozdDQAAjriq+tvrtSufAABg8kZNiqtqo6ouXrt2bcxuAAAwcaMmxd19qbvPnzhxYsxuAAAwcconAACYPEkxAACTN+rqE1W1kWRjbW1tlOOfvvDez3r9/NvfOko/AAAYl5piAAAmT/kEAACTJykGAGDyJMUAAEyepBgAgMlzRzsAACbP6hMAAEye8gkAACZPUgwAwORJigEAmDxJMQAAk7cvSXFVvbaqnqyqb9+P/QMAwDItlBRX1YNV9XJVPbWt/WxVPVtVV6vqwty3fjLJu5fZUQAA2C+LzhQ/lOTsfENVHUvyQJK7kpxJcq6qzlTVNyf5cJKPLbGfAACwb25a5E3d/XhVnd7WfGeSq939XJJU1SNJ7k7y+Ulem61E+Z+r6nJ3//vSegwAAEu2UFK8g5NJXph7vZnkq7v7/iSpqh9M8omdEuKqOp/kfJKcOnVqQDcAAGCYIUlxXaetX33S/dCNNu7ui1X1UpKN48ePv2lAPwAAYJAhq09sJrlt7vWtSV7czQ7c5hkAgFUwJCl+IskdVXV7VR1Pck+SR3ezg6raqKqL165dG9ANAAAYZtEl2R5O8v4kb6iqzaq6t7s/neT+JI8leSbJu7v76d0c3EwxAACrYNHVJ87t0H45yeW9HryqNpJsrK2t7XUXAAAw2Ki3eTZTDADAKhg1KVZTDADAKjBTDADA5I2aFAMAwCpQPgEAwOQpnwAAYPKUTwAAMHnKJwAAmDzlEwAATJ7yCQAAJk9SDADA5KkpBgBg8tQUAwAweconAACYPEkxAACTd9PYHVglpy+899Xnz7/9rSP2BACAg2SmGACAybP6BAAAk2f1CQAAJk/5BAAAkycpBgBg8iTFAABMnqQYAIDJW3pSXFX/vareWVXvqaofXvb+AQBg2RZKiqvqwap6uaqe2tZ+tqqeraqrVXUhSbr7me5+W5LvSbK+/C4DAMByLTpT/FCSs/MNVXUsyQNJ7kpyJsm5qjoz+953JPn/Sf50aT09YKcvvPfVBwAAR9tCSXF3P57kk9ua70xytbuf6+5PJXkkyd2z9z/a3V+X5PuW2VkAANgPNw3Y9mSSF+Zebyb56qp6c5LvSvKaJJd32riqzic5nySnTp0a0A0AABhmSFJc12nr7n5fkvf9Vxt398WqeinJxvHjx980oB8AADDIkNUnNpPcNvf61iQv7mYHbvMMAMAqGJIUP5Hkjqq6vaqOJ7knyaO72UFVbVTVxWvXrg3oBgAADLPokmwPJ3l/kjdU1WZV3dvdn05yf5LHkjyT5N3d/fRuDm6mGACAVbBQTXF3n9uh/XJucDHdf6WqNpJsrK2t7XUXAAAw2Ki3eTZTDADAKhiy+sRgh2WmeP4GHs+//a0j9gQAgP1gphgAgMkbNSkGAIBVMGpSbEk2AABWgfIJAAAmT/kEAACTp3wCAIDJG3VJtu6+lOTS+vr6fWP2YzcszwYAcPQonwAAYPIkxQAATJ6aYgAAJs+SbAAATJ7yCQAAJk9SDADA5EmKAQCYvFHXKT7srFkMAHA0WH0CAIDJs/oEAACTp6YYAIDJkxQDADB5kmIAACZPUgwAwOTtS1JcVd9ZVb9eVX9YVd+6H8cAAIBlWTgprqoHq+rlqnpqW/vZqnq2qq5W1YUk6e7/2933JfnBJN+71B4DAMCS7ebmHQ8l+ZUkv/VKQ1UdS/JAkm9Jspnkiap6tLs/PHvLz8y+f+S5kQcAwOG18Exxdz+e5JPbmu9McrW7n+vuTyV5JMndteXnk/xRd//F8roLAADLN7Sm+GSSF+Zeb87afjTJNyf57qp62/U2rKrzVXWlqq58/OMfH9gNAADYu92UT1xPXaetu/sdSd5xow27+2KSi0myvr7eA/sBAAB7NjQp3kxy29zrW5O8uOjGVbWRZGNtbW1gN4Ahde1q4gGYuqFJ8RNJ7qiq25P8XZJ7kvyvwb0CPoukFQD218JJcVU9nOTNSW6uqs0kP9vd76qq+5M8luRYkge7++lF99ndl5JcWl9fv2933QYWNZ9Qz5NcA8BnLJwUd/e5HdovJ7m8l4Mrn2BKdprtXaQdANhfQ8snBjFTzKq7UWK6HzOtu02EDzJxVsIBwFE2alJ8VGeKJQ+8YqekdUgyu8i2y9r/Tj+/+/UzbuwAMBYzxbAEhzGZ2+/kevv2iyTYADCWUZNiOIokeQBw+CifgD2S/ALA0aF8gklxOn/5tv97LasO2VJyABwk5RNM1mGsAz4M/KcCgMNI+cQ+k3gdDhK5g2UpOQBWjfIJjiSJ0NE1JLZ+LgDYifIJ4NCS5AKwLJLiA+QPOKwO4xGAeWqKOTLUBU/bfie5kmiAo626e+w+ZH19va9cuXLgxx0zifJHdfkkxSzD/Nhc5GfKWAY4XKrqye5e396ufIJDx4wdALBskmKAOc44AEyTpBhgAGcuAI6Gzxm7AwAAMDarT3CoOdUNACzDqDPF3X2pu8+fOHFizG4AADBxaooBlkR9McDhpaYYAIDJM1MMcADMIgOsNknxSKb+B3Lqn5+jb9GLQI0FgNUgKWZlSRY4qnZKmHf7M2+MACzP0muKq+r1VfWuqnrPsvcNAAD7YaGZ4qp6MMm3J3m5u79irv1skl9OcizJb3T327v7uST3SooXZ7bnMxaZQQMAWLZFZ4ofSnJ2vqGqjiV5IMldSc4kOVdVZ5baOwAAOAALzRR39+NVdXpb851Jrs5mhlNVjyS5O8mHF9lnVZ1Pcj5JTp06tWB3jz6zxkBysL8L/N4BGFZTfDLJC3OvN5OcrKovqap3JvmqqvqpnTbu7ovdvd7d67fccsuAbgAAwDBDVp+o67R1d/99krcttIOqjSQba2trA7rBYadeGG7MGAHYf0OS4s0kt829vjXJi8O6w1HjtCyMa6cxKNEG+GxDyieeSHJHVd1eVceT3JPk0d3soLsvdff5EydODOgGAAAMs+iSbA8neXOSm6tqM8nPdve7qur+JI9la0m2B7v76d0cXPnEtJiZgv2zrPG1yNmdIWeAtvfTGSRgVSy6+sS5HdovJ7m814N396Ukl9bX1+/b6z4AAGCopd/RDgAADpshF9oNpnzixlykBizTkBKLgyh/8jsPGNOoM8UutAMAYBWYKQbgupY1s7yXWV+zxsBBM1MMAMDkudAOAIDJUz5xhDjdCBy03a5rDLCqlE8AADB5yicAAJg8STEAAJMnKQYAYPJcaHdEuegOOAxW4SI8vy+BxIV2AACgfAIAACTFAABMnqQYAIDJc6HdIXfQF6nsdLz5i1NW4cIZ4ODt19jf7V3zlnWx3G73ucjnX7RvQz6PCwdhb1xoBwDA5CmfAABg8iTFAABMnqQYAIDJkxQDADB5kmIAACZv6UuyVdVrk/xqkk8leV93/86yjwEAAMu00ExxVT1YVS9X1VPb2s9W1bNVdbWqLsyavyvJe7r7viTfseT+AgDA0i1aPvFQkrPzDVV1LMkDSe5KcibJuao6k+TWJC/M3vZvy+kmAADsn4XKJ7r78ao6va35ziRXu/u5JKmqR5LcnWQzW4nxB3ODpLuqzic5nySnTp3abb8nZ1l3N5q3zLvQuYsdcBCG3N1uWb+nVvGOcav22Zb5b7RIPPe7r6sY8yGG3K1xVX4u9sOQC+1O5jMzwslWMnwyyR8k+Z9V9WtJLu20cXdf7O717l6/5ZZbBnQDAACGGXKhXV2nrbv7n5L80EI7qNpIsrG2tjagGwAAMMyQmeLNJLfNvb41yYu72UF3X+ru8ydOnBjQDQAAGGZIUvxEkjuq6vaqOp7kniSP7mYHVbVRVRevXbs2oBsAADDMokuyPZzk/UneUFWbVXVvd386yf1JHkvyTJJ3d/fTuzm4mWIAAFbBoqtPnNuh/XKSy3s9uJpiAABWwai3eTZTDADAKqjuHu/gs5niJN+b5CMjdOHmJJ8Y4biMQ7ynQ6ynRbynQ6ynYz9j/WXd/Z/WAx41KR5bVV3p7vWx+8HBEO/pEOtpEe/pEOvpGCPWo5ZPAADAKpAUAwAweVNPii+O3QEOlHhPh1hPi3hPh1hPx4HHetI1xQAAkJgpBgCA6SbFVXW2qp6tqqtVdWHs/rA3VfV8Vf1VVX2wqq7M2r64qv6kqj4y+/pFc+//qVnMn62qb5trf9NsP1er6h1VVWN8Hj6jqh6sqper6qm5tqXFtqpeU1W/O2v/86o6fZCfj8+2Q7x/rqr+bja+P1hVb5n7nngfUlV1W1X9v6p6pqqerqofm7Ub30fMDWK9mmO7uyf3SHIsyUeTvD7J8SR/meTM2P3y2FMsn09y87a2X0hyYfb8QpKfnz0/M4v1a5LcPvsZODb73geSfG2SSvJHSe4a+7NN/ZHkG5O8MclT+xHbJD+S5J2z5/ck+d2xP/OUHzvE++eS/MR13iveh/iR5HVJ3jh7/gVJ/noWU+P7iD1uEOuVHNtTnSm+M8nV7n6uuz+V5JEkd4/cJ5bn7iS/OXv+m0m+c679ke7+l+7+myRXk9xZVa9L8oXd/f7eGlW/NbcNI+nux5N8clvzMmM7v6/3JPkmZwjGs0O8dyLeh1h3v9TdfzF7/o9JnklyMsb3kXODWO9k1FhPNSk+meSFudebuXGQWF2d5I+r6smqOj9r+2/d/VKyNSCTfOmsfae4n5w9397O6llmbF/dprs/neRaki/Zt56zV/dX1Ydm5RWvnE4X7yNidqr7q5L8eYzvI21brJMVHNtTTYqv9z8Iy3AcTl/f3W9McleS/11V33iD9+4Udz8Ph99eYivuq+/Xknx5kq9M8lKSX5y1i/cRUFWfn+T3k/x4d//Djd56nTbxPkSuE+uVHNtTTYo3k9w29/rWJC+O1BcG6O4XZ19fTvJ/slUa87HZqZbMvr48e/tOcd+cPd/ezupZZmxf3aaqbkpyIoufvucAdPfHuvvfuvvfk/x6tsZ3It6HXlV9braSpN/p7j+YNRvfR9D1Yr2qY3uqSfETSe6oqtur6ni2CrMfHblP7FJVvbaqvuCV50m+NclT2YrlD8ze9gNJ/nD2/NEk98yuVL09yR1JPjA7TfePVfU1szqk75/bhtWyzNjO7+u7k/zZrFaNFfFKgjTzP7I1vhPxPtRmsXlXkme6+5fmvmV8HzE7xXplx/bYVyaO9UjylmxdBfnRJD89dn889hTD12frKtW/TPL0K3HMVi3Rnyb5yOzrF89t89OzmD+buRUmkqzPBuVHk/xKZje28Rg1vg9n67Tav2ZrJuDeZcY2yecl+b1sXcjxgSSvH/szT/mxQ7x/O8lfJfnQ7A/f68T78D+SfEO2Tm9/KMkHZ4+3GN9H73GDWK/k2HZHOwAAJm+q5RMAAPAqSTEAAJMnKQYAYPIkxQAATJ6kGACAyZMUAwAweZJiAAAmT1IMAMDk/Qc0uYmbKt+qYgAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQwklEQVR4nO3df4il910v8PfHxK1QdVGTK2WTdVMnlBvuH9oO0asigr82rWPUK7fJvXBVQpaqEf1DcEVB/6yCF25ptKw2xIokxlp1l67kSr0lXAg2G6k1aYjd5kYyJjSthVVE7I1+/GNO0tNxZ3tmnjPznJnn9YLDnPOdc57zOfuZZ+az3+fzfJ/q7gAAwJR9ydgBAADA2BTFAABMnqIYAIDJUxQDADB5imIAACZPUQwAwORdP3YASXLDDTf0qVOnxg4DAIAj7sknn/xMd9+4fXwliuJTp07l0qVLY4cBAMARV1V/c7Vx7RMAAEzeqEVxVW1U1bkrV66MGQYAABM3alHc3Re6+8zx48fHDAMAgInTPgEAwOQpigEAmLxRV5+oqo0kG2tra6O8/6mzH/yCx8+/822jxAEAwLj0FAMAMHnaJwAAmDxFMQAAk6coBgBg8hTFAABMnivaAQAweVafAABg8rRPAAAweYpiAAAmT1EMAMDkKYoBAJi8fSmKq+r1VfVkVX3ffmwfAACWaaGiuKoeqKqXq+qpbeOnq+rZqrpcVWfnvvVzSR5ZZqAAALBfFp0pfjDJ6fmBqrouyf1J7khyW5K7q+q2qvquJB9P8qklxgkAAPvm+kWe1N2PVdWpbcO3J7nc3c8lSVU9nOTOJF+e5PXZKpT/qaoudve/Li1iAABYsoWK4h2cSPLC3OPNJN/U3fclSVX9aJLP7FQQV9WZJGeS5OTJkwPCAACAYYYUxXWVsX7tTveD13pxd5+rqpeSbBw7duwtA+IAAIBBhqw+sZnk5rnHNyV5cTcbcJlnAABWwZCi+Ikkt1bVLVV1LMldSc7vZgNVtVFV565cuTIgDAAAGGbRJdkeSvJ4kjdV1WZV3dPdryS5L8mjSZ5J8kh3P72bNzdTDADAKlh09Ym7dxi/mOTiXt+8qjaSbKytre11EwAAMNiol3k2UwwAwCoYtSjWUwwAwCowUwwAwOSNWhQDAMAq0D4BAMDkaZ8AAGDytE8AADB52icAAJg87RMAAEye9gkAACZPUQwAwOTpKQYAYPL0FAMAMHnaJwAAmDxFMQAAk3f92AGsklNnP/ja/eff+bYRIwEA4CCZKQYAYPKsPgEAwORZfQIAgMnTPgEAwOQpigEAmDxFMQAAk6coBgBg8pZeFFfVf6yq91TV+6vqx5e9fQAAWLaFiuKqeqCqXq6qp7aNn66qZ6vqclWdTZLufqa735HkvyZZX37IAACwXIvOFD+Y5PT8QFVdl+T+JHckuS3J3VV12+x735/k/yb50NIiPWCnzn7wtRsAAEfbQkVxdz+W5LPbhm9Pcrm7n+vuzyV5OMmds+ef7+5vSfLflxksAADsh+sHvPZEkhfmHm8m+aaq+o4kP5TkdUku7vTiqjqT5EySnDx5ckAYAAAwzJCiuK4y1t394SQf/mIv7u5zVfVSko1jx469ZUAcAAAwyJDVJzaT3Dz3+KYkL+5mAy7zDADAKhhSFD+R5NaquqWqjiW5K8n53Wygqjaq6tyVK1cGhAEAAMMsuiTbQ0keT/Kmqtqsqnu6+5Uk9yV5NMkzSR7p7qd38+ZmigEAWAUL9RR39907jF/MNU6m+2KqaiPJxtra2l43AQAAg416mWczxQAArIJRi2I9xQAArIIhS7IN1t0XklxYX1+/d8w4vpj5q9o9/863jRgJAAD7YdSZYgAAWAXaJwAAmDwn2gEAMHnaJwAAmDztEwAATJ7VJ3bJShQAAEeP9gkAACZPUQwAwOTpKQYAYPIsyQYAwORpnwAAYPIUxQAATJ6iGACAyRt1neLDzprFAABHg9UnAACYPKtPAAAweXqKAQCYPEUxAACTpygGAGDyFMUAAEzevhTFVfUDVfWbVfXHVfU9+/EeAACwLAsXxVX1QFW9XFVPbRs/XVXPVtXlqjqbJN39R919b5IfTfL2pUYMAABLtpuLdzyY5N1J3vfqQFVdl+T+JN+dZDPJE1V1vrs/PnvKL86+f+S5kAcAwOG18Exxdz+W5LPbhm9Pcrm7n+vuzyV5OMmdteVXkvxJd//F8sIFAIDlG9pTfCLJC3OPN2djP5Xku5L8cFW942ovrKozVXWpqi59+tOfHhgGAADs3W7aJ66mrjLW3f2uJO+61gu7+1xVvZRk49ixY28ZGAcAAOzZ0KJ4M8nNc49vSvLioi/u7gtJLqyvr987MA6YvCF97XriAZi6oUXxE0lurapbkvxtkruS/LdFX1xVG0k21tbWBoYBR5uiFQD2126WZHsoyeNJ3lRVm1V1T3e/kuS+JI8meSbJI9399KLb7O4L3X3m+PHju40b2INTZz/42g0A+LyFZ4q7++4dxi8mubiXNzdTzJTsdrZ3WYWrAhgAvrih7ROD6Clm1R1E28KQovUgC14tHAAcZaMWxUd1pljxcDRtL0CH5PawFMKLxOBnHICjwEwxLMFOReJYBexhKrp3ej/FNgAHadSiGI6iVZjJXcRBxGlGGYDDYugV7Qapqo2qOnflypUxwwAAYOK0TzApi8xcLjqDelhmhPfbor3WQ1bfMMsMwH7TPsFkKbr2x378Z0GuANhvVp/YZ/6Yw79nKTkAVo32CY6ksS6Uwf4bUuQqkAHYifYJ4NBS5AKwLIriA+QPOKwO+yMA8/QUc2RogWA/KaIBjrbq7rFjyPr6el+6dOnA33fMIsof1eVTFLMMu70ioX0Z4HCpqie7e337uPYJDh0zdgDAsimKAeY44gAwTYpigAEcuQA4Gr5k7AAAAGBsVp/gUHOoGwBYhlFnirv7QnefOX78+JhhAAAwcXqKAZZEfzHA4aWnGACAyTNTDHAAzCIDrDZF8Uim/gdy6p+fo2/Rk0DtCwCrQVHMylIscFTtVDDv9mfePgKwPEvvKa6qN1bVe6vq/cveNgAA7IeFZoqr6oEk35fk5e7+T3Pjp5P8ryTXJfmt7n5ndz+X5B5FMXuxyAwaAMCyLdo+8WCSdyd536sDVXVdkvuTfHeSzSRPVNX57v74soM86hwCBQAY10JFcXc/VlWntg3fnuTybGY4VfVwkjuTLFQUV9WZJGeS5OTJkwuGe/QpkIHkYH8X+L0DMKyn+ESSF+YebyY5UVVfU1XvSfKNVfXzO724u89193p3r994440DwgAAgGGGrD5RVxnr7v67JO9YaANVG0k21tbWBoTBYadfGK7NPgKw/4YUxZtJbp57fFOSF4eFw1HjsCyMa6d9UKEN8IWGtE88keTWqrqlqo4luSvJ+d1soLsvdPeZ48ePDwgDAACGWXRJtoeSfEeSG6pqM8kvdfd7q+q+JI9ma0m2B7r76d28ufaJaTEzBftnWfvXIkd3hhwB2h6nI0jAqlh09Ym7dxi/mOTiXt+8uy8kubC+vn7vXrcBAABDLf2KdgAAcNgMOdFuMO0T1+YkNWCZhrRYHET7k995wJhGnSl2oh0AAKvATDEAV7WsmeW9zPqaNQYOmpliAAAmz4l2AABMnvaJI8ThRuCg7XZdY4BVpX0CAIDJ0z4BAMDkKYoBAJg8RTEAAJPnRLsjykl3wGGwCifh+X0JJE60AwAA7RMAAKAoBgBg8hTFAABMnhPtDrmDPkllp/ebPzllFU6cAQ7efu37u71q3rJOltvtNhf5/IvGNuTzOHEQ9saJdgAATJ72CQAAJk9RDADA5CmKAQCYPEUxAACTpygGAGDylr4kW1W9PsmvJ/lckg939+8u+z0AAGCZFpoprqoHqurlqnpq2/jpqnq2qi5X1dnZ8A8leX9335vk+5ccLwAALN2i7RMPJjk9P1BV1yW5P8kdSW5LcndV3ZbkpiQvzJ72L8sJEwAA9s9C7RPd/VhVndo2fHuSy939XJJU1cNJ7kyyma3C+KO5RtFdVWeSnEmSkydP7jbuyVnW1Y3mLfMqdK5iBxyEIVe3W9bvqVW8YtyqfbZl/hstks/9jnUVcz7EkKs1rsrPxX4YcqLdiXx+RjjZKoZPJPlAkv9SVb+R5MJOL+7uc9293t3rN95444AwAABgmCEn2tVVxrq7/zHJjy20gaqNJBtra2sDwgAAgGGGzBRvJrl57vFNSV7czQa6+0J3nzl+/PiAMAAAYJghRfETSW6tqluq6liSu5Kc380Gqmqjqs5duXJlQBgAADDMokuyPZTk8SRvqqrNqrqnu19Jcl+SR5M8k+SR7n56N29uphgAgFWw6OoTd+8wfjHJxb2+uZ5iAABWwaiXeTZTDADAKqjuHu/NZzPFSd6e5BMjhHBDks+M8L6MQ76nQ66nRb6nQ66nYz9z/XXd/e/WAx61KB5bVV3q7vWx4+BgyPd0yPW0yPd0yPV0jJHrUdsnAABgFSiKAQCYvKkXxefGDoADJd/TIdfTIt/TIdfTceC5nnRPMQAAJGaKAQBgukVxVZ2uqmer6nJVnR07Hvamqp6vqr+qqo9W1aXZ2FdX1Z9W1SdmX79q7vk/P8v5s1X1vXPjb5lt53JVvauqaozPw+dV1QNV9XJVPTU3trTcVtXrqur3ZuN/XlWnDvLz8YV2yPcvV9Xfzvbvj1bVW+e+J9+HVFXdXFX/p6qeqaqnq+qnZ+P27yPmGrlezX27uyd3S3Jdkk8meWOSY0n+MsltY8fltqdcPp/khm1jv5rk7Oz+2SS/Mrt/2yzXr0tyy+xn4LrZ9z6S5D8nqSR/kuSOsT/b1G9Jvj3Jm5M8tR+5TfITSd4zu39Xkt8b+zNP+bZDvn85yc9e5bnyfYhvSd6Q5M2z+1+R5K9nObV/H7HbNXK9kvv2VGeKb09yubuf6+7PJXk4yZ0jx8Ty3Jnkt2f3fzvJD8yNP9zd/9zd/y/J5SS3V9Ubknxldz/eW3vV++Zew0i6+7Ekn902vMzczm/r/Um+0xGC8eyQ753I9yHW3S9191/M7v9DkmeSnIj9+8i5Rq53Mmqup1oUn0jywtzjzVw7SayuTvK/q+rJqjozG/va7n4p2dohk/yH2fhOeT8xu799nNWzzNy+9prufiXJlSRfs2+Rs1f3VdXHZu0Vrx5Ol+8jYnao+xuT/Hns30fatlwnK7hvT7Uovtr/ICzDcTh9a3e/OckdSX6yqr79Gs/dKe9+Hg6/veRW3lffbyT5+iTfkOSlJL82G5fvI6CqvjzJHyT5me7++2s99Spj8n2IXCXXK7lvT7Uo3kxy89zjm5K8OFIsDNDdL86+vpzkD7PVGvOp2aGWzL6+PHv6TnnfnN3fPs7qWWZuX3tNVV2f5HgWP3zPAejuT3X3v3T3vyb5zWzt34l8H3pV9aXZKpJ+t7s/MBu2fx9BV8v1qu7bUy2Kn0hya1XdUlXHstWYfX7kmNilqnp9VX3Fq/eTfE+Sp7KVyx+ZPe1Hkvzx7P75JHfNzlS9JcmtST4yO0z3D1X1zbM+pP8x9xpWyzJzO7+tH07yZ7NeNVbEqwXSzA9ma/9O5PtQm+XmvUme6e7/Ofct+/cRs1OuV3bfHvvMxLFuSd6arbMgP5nkF8aOx21POXxjts5S/cskT7+ax2z1En0oySdmX7967jW/MMv5s5lbYSLJ+myn/GSSd2d2YRu3UfP7ULYOq/3/bM0E3LPM3Cb5siS/n60TOT6S5I1jf+Yp33bI9+8k+askH5v94XuDfB/+W5Jvy9bh7Y8l+ejs9lb799G7XSPXK7lvu6IdAACTN9X2CQAAeI2iGACAyVMUAwAweYpiAAAmT1EMAMDkKYoBAJg8RTEAAJOnKAYAYPL+DVPHmcettkCJAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -476,12 +567,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQPklEQVR4nO3db4xld1kH8O/j1iWm1AnaQsi2a4tTGhte8GdSVBLCC9CtMBTxT7oYRdOwQqjRFyYWNYE3xmrUBEKFrNAUEmzTIGA3LBZjJI1Jo9uSKi2b6lqrHdpQkGQlxtgUHl/MLR2Hne2dPXf23pnz+SQ3c89v7jnnuX32NE9+85zfqe4OAACM2ffMOwAAAJg3RTEAAKOnKAYAYPQUxQAAjJ6iGACA0VMUAwAwehfM8+RVtZpk9aKLLnrHS1/60nmGAgDACNx///1f7+5LNo/XIqxTvLKy0vfdd9+8wwAAYI+rqvu7e2XzuPYJAABGT1EMAMDozbUorqrVqjp6+vTpeYYBAMDIzbUo7u5j3X1kaWlpnmEAADBy2icAABi9uS7JNm+X3/TZ/7f96M1vnFMkAADMk5liAABGT1EMAMDoWX0CAIDRs/oEAACjp30CAIDRUxQDADB6imIAAEZPUQwAwOgpigEAGL0dKYqr6sKqur+q3rQTxwcAgFmaqiiuqlur6smqenDT+KGqeriqTlXVTRt+9VtJ7pxloAAAsFOmnSm+LcmhjQNVtS/JLUmuTXJ1ksNVdXVVvT7Jl5N8dYZxAgDAjrlgmg919z1Vdfmm4WuSnOruR5Kkqu5Icl2S5ye5MOuF8v9U1fHu/vbmY1bVkSRHkuTgwYPnGj8AAAw2VVG8hQNJHtuwvZbk1d19Y5JU1S8n+fqZCuIk6e6jSY4mycrKSg+IAwAABhlSFNcZxr5T3Hb3bc95gKrVJKvLy8sDwgAAgGGGrD6xluSyDduXJnl8Owfo7mPdfWRpaWlAGAAAMMyQovhEkiur6oqq2p/k+iR3becAVbVaVUdPnz49IAwAABhm2iXZbk9yb5Krqmqtqm7o7qeT3Jjk7iQnk9zZ3Q9t5+RmigEAWATTrj5xeIvx40mOn+vJ9RQDALAI5vqYZzPFAAAsgrkWxXqKAQBYBGaKAQAYvbkWxQAAsAi0TwAAMHraJwAAGD3tEwAAjJ72CQAARk/7BAAAo6d9AgCA0VMUAwAwenqKAQAYPT3FAACMnvYJAABGT1EMAMDoKYoBABg9RTEAAKNn9QkAAEbP6hMAAIye9gkAAEZPUQwAwOgpigEAGD1FMQAAo6coBgBg9GZeFFfVj1TVh6vqk1X1rlkfHwAAZm2qoriqbq2qJ6vqwU3jh6rq4ao6VVU3JUl3n+zudyb5+SQrsw8ZAABma9qZ4tuSHNo4UFX7ktyS5NokVyc5XFVXT3735iR/l+RvZhYpAADskKmK4u6+J8k3Ng1fk+RUdz/S3U8luSPJdZPP39XdP57kF7Y6ZlUdqar7quq+r33ta+cWPQAAzMAFA/Y9kOSxDdtrSV5dVa9L8tYkz0tyfKudu/tokqNJsrKy0gPiAACAQYYUxXWGse7uLyT5wlQHqFpNsrq8vDwgDAAAGGZIUbyW5LIN25cmeXxYOIvv8ps+e8bxR29+43mOBACAWRlSFJ9IcmVVXZHkK0muT/K27Rygu48lObaysvKOAXHMzMaCV5ELADAe0y7JdnuSe5NcVVVrVXVDdz+d5MYkdyc5meTO7n5oOyevqtWqOnr69Ontxg0AADMz1Uxxdx/eYvx4znIz3RTHXaiZ4iHMMgMA7F4e8wwAwOjNtSjWPgEAwCKYa1Hc3ce6+8jS0tI8wwAAYOSGrD4x2F5dp1h/MQDA7jLXoni33Gi31drEAADsDW60AwBg9OY6UzwGnoAHALD4rD4BAMDoWX0CAIDR01MMAMDo6SmeE8u2AQAsDj3FAACMnp5iAABGT/vEArBsGwDAfCmKF5hiGQDg/LD6BAAAo6coBgBg9ObaPlFVq0lWl5eX5xnGGW3VurAIpolNiwUAwPTmWhR397Ekx1ZWVt4xzzj2IusgAwBMz412I6BABgA4O0XxyCiQAQC+mxvtAAAYPUUxAACjtyPtE1X1liRvTPLCJLd09+d34jwMo5UCAGDd1EVxVd2a5E1Jnuzul20YP5Tk/Un2JflId9/c3Z9J8pmqekGSP0qiKF5wZ1vmTcEMAOx125kpvi3JB5N8/JmBqtqX5JYkb0iyluREVd3V3V+efOR3J79nFzOjDADsdVMXxd19T1Vdvmn4miSnuvuRJKmqO5JcV1Unk9yc5HPd/cUZxcoCUCADAHvR0J7iA0ke27C9luTVSX4tyeuTLFXVcnd/ePOOVXUkyZEkOXjw4MAwmAcFMgCwVwwtiusMY93dH0jygbPt2N1Hq+qJJKv79+9/1cA4mLOtCmSFMwCwGwwtiteSXLZh+9Ikj0+7s8c8j4sCGQBYVEPXKT6R5MqquqKq9ie5Psld0+5cVatVdfT06dMDwwAAgHO3nSXZbk/yuiQXV9Vakvd290er6sYkd2d9SbZbu/uhaY9ppnhvOtvybgAAi2g7q08c3mL8eJLj53LyqlpNsrq8vHwuu7MHabEAAOZhR55oNy0zxZwLhTMAMGtzLYrNFI+XFgsAYJGYKWZhmREGAM6XuRbFMK0hM8uKawDguWifYFQUyADAmQxdp3iQ7j7W3UeWlpbmGQYAACOnfYI9w817AMC50j7BrqbXGACYBatPQBTIADB22idgEwUyAIyPohjOQoEMAOMw19UnAABgEbjRDqZ0tpv6zCIDwO5mnWIAAEZPTzHsoEXoSV6EGABg0SmKYc4UrQAwf260AwBg9NxoBzMwzZP1zAgDwOJyox0AAKOnpxh2ma1mnM1EA8C501MMAMDoKYoBABg97RMwB27MA4DFoiiGBTJNsQwAzN7Mi+KqekmS30my1N0/O+vjA89SRAPAbExVFFfVrUnelOTJ7n7ZhvFDSd6fZF+Sj3T3zd39SJIbquqTOxEw8Ny2Kpa325KhhQOAsZh2pvi2JB9M8vFnBqpqX5JbkrwhyVqSE1V1V3d/edZBAjtL8QvA2E21+kR335PkG5uGr0lyqrsf6e6nktyR5LoZxwcAADtuSE/xgSSPbdheS/LqqvrBJL+X5BVV9Z7u/v0z7VxVR5IcSZKDBw8OCAM438wsA7DXDCmK6wxj3d3/meSdz7Vzdx+tqieSrO7fv/9VA+KAPc8NdQCws4Y8vGMtyWUbti9N8vh2DtDdx7r7yNLS0oAwAABgmCEzxSeSXFlVVyT5SpLrk7xtOweoqtUkq8vLywPCAM7FNCtUAMBYTDVTXFW3J7k3yVVVtVZVN3T300luTHJ3kpNJ7uzuh7ZzcjPFAAAsgqlmirv78Bbjx5McP9eTmymGcXKjHgCLZkhP8WBmigEAWAQzf8zzdpgpBuZlq9lqs9gA42SmGACA0ZtrUQwAAItA+wQwlXNZwm2rtoRp93+u42zV3rDVMXeiHUK7BcDeoH0CAIDR0z4BAMDoaZ8AFt40LRY78SS+ebZGaMsAOL+0TwAAMHraJwAAGD1FMQAAo6enGNgxO9Hnez6Pv1PnGtIvfD57jc/n0nYA86anGACA0dM+AQDA6CmKAQAYPUUxAACjpygGAGD0rD4BjN5OPw3vfJ97mnOdzxUkpj3vbnyK326MGTgzq08AADB62icAABg9RTEAAKOnKAYAYPQUxQAAjJ6iGACA0Zv5kmxVdWGSP03yVJIvdPcnZn0OAACYpalmiqvq1qp6sqoe3DR+qKoerqpTVXXTZPitST7Z3e9I8uYZxwsAADM3bfvEbUkObRyoqn1JbklybZKrkxyuqquTXJrkscnHvjWbMAEAYOdM1T7R3fdU1eWbhq9Jcqq7H0mSqrojyXVJ1rJeGD+QsxTdVXUkyZEkOXjw4HbjBti2nX563E4df5rjzuvJeFvZ6uluQ5/0N81T46bZd7vfYbtPrhv6pLsh33+nYpr1caY5/k6dYyfsRM7OdvxprrFF+2+3yLElw260O5BnZ4ST9WL4QJJPJfmZqvpQkmNb7dzdR7t7pbtXLrnkkgFhAADAMENutKszjHV3/3eSX5nqAFWrSVaXl5cHhAEAAMMMmSleS3LZhu1Lkzy+nQN097HuPrK0tDQgDAAAGGZIUXwiyZVVdUVV7U9yfZK7tnOAqlqtqqOnT58eEAYAAAwz7ZJstye5N8lVVbVWVTd099NJbkxyd5KTSe7s7oe2c3IzxQAALIJpV584vMX48STHz/XkeooBAFgEc33Ms5liAAAWQXX3vGNIVX0tyb/P4dQXJ/n6HM7LzpHTvUdO9x453XvkdO/Zyzn9oe7+rvWAF6Ionpequq+7V+YdB7Mjp3uPnO49crr3yOneM8aczrV9AgAAFoGiGACA0Rt7UXx03gEwc3K698jp3iOne4+c7j2jy+moe4oBACAxUwwAAOMtiqvqUFU9XFWnquqmecfD9Krq0ar6UlU9UFX3TcZ+oKr+uqr+ZfLzBRs+/55Jnh+uqp+cX+Q8o6puraonq+rBDWPbzmFVvWryb+FUVX2gqup8fxe2zOf7quork+v0gar6qQ2/k88FV1WXVdXfVtXJqnqoqn59Mu463aXOklPX6jO6e3SvJPuS/GuSlyTZn+Qfk1w977i8ps7fo0ku3jT2h0lumry/KckfTN5fPcnv85JcMcn7vnl/h7G/krw2ySuTPDgkh0n+IcmPJakkn0ty7by/2xhfW+TzfUl+8wyflc9d8Ery4iSvnLy/KMk/T3LnOt2lr7Pk1LU6eY11pviaJKe6+5HufirJHUmum3NMDHNdko9N3n8syVs2jN/R3f/b3f+W5FTW888cdfc9Sb6xaXhbOayqFyf5/u6+t9f/L/3xDftwHm2Rz63I5y7Q3U909xcn77+Z5GSSA3Gd7lpnyelWRpfTsRbFB5I8tmF7LWf/h8Fi6SSfr6r7q+rIZOxF3f1Esn7hJ3nhZFyud4/t5vDA5P3mcRbHjVX1T5P2imf+zC6fu0xVXZ7kFUn+Pq7TPWFTThPXapLxFsVn6n2xDMfu8ZrufmWSa5O8u6pee5bPyvXut1UO5XaxfSjJDyd5eZInkvzxZFw+d5Gqen6Sv0jyG939X2f76BnG5HUBnSGnrtWJsRbFa0ku27B9aZLH5xQL29Tdj09+Ppnk01lvh/jq5E86mfx8cvJxud49tpvDtcn7zeMsgO7+and/q7u/neTP8mzbknzuElX1vVkvnj7R3Z+aDLtOd7Ez5dS1+qyxFsUnklxZVVdU1f4k1ye5a84xMYWqurCqLnrmfZKfSPJg1vP39snH3p7kLyfv70pyfVU9r6quSHJl1m8QYPFsK4eTP91+s6p+dHLn8y9t2Ic5e6ZwmvjprF+niXzuCpMcfDTJye7+kw2/cp3uUlvl1LX6rAvmHcA8dPfTVXVjkruzvhLFrd390JzDYjovSvLpyeovFyT58+7+q6o6keTOqrohyX8k+bkk6e6HqurOJF9O8nSSd3f3t+YTOs+oqtuTvC7JxVW1luS9SW7O9nP4riS3Jfm+rN8B/bnz+DWY2CKfr6uql2f9z6qPJvnVRD53kdck+cUkX6qqByZjvx3X6W62VU4Pu1bXeaIdAACjN9b2CQAA+A5FMQAAo6coBgBg9BTFAACMnqIYAIDRUxQDADB6imIAAEZPUQwAwOj9HzuYeTCzYv4FAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQUUlEQVR4nO3db4xld1kH8O/j1iWm1IlKJWTbtcUtjQ0v+DMpKgnhBeBWGIqIpotRNA0jhBp9YeKiJvLGWI2aQKiYBZtCgm0a5E83LBZjJI1Jo7slVVo21bVWO21DQZKVGCMpPL7Yu3Qcd7Z39tzZe2fO55Pc7D2/ueec5/bZs3n6m+f8TnV3AABgzL5r3gEAAMC8KYoBABg9RTEAAKOnKAYAYPQUxQAAjJ6iGACA0btknievqpUkK5dddtk7X/KSl8wzFAAARuCBBx74WndfvnG8FmGd4uXl5T5x4sS8wwAAYJerqge6e3njuPYJAABGT1EMAMDozbUorqqVqjpy+vTpeYYBAMDIzbUo7u6j3b26tLQ0zzAAABg57RMAAIzeXJdkm7erDn/2/2w/dusb5xQJAADzZKYYAIDRUxQDADB6Vp8AAGD0rD4BAMDoaZ8AAGD0FMUAAIyeohgAgNFTFAMAMHqKYgAARm9biuKqurSqHqiqN23H8QEAYJamKoqr6vaqerqqHtowfrCqHqmqU1V1eN2PfiPJ3bMMFAAAtsu0M8V3JDm4fqCq9iS5LckNSa5Lcqiqrquq1yX5cpKvzDBOAADYNpdM86Huvq+qrtowfH2SU939aJJU1V1Jbkzy/CSX5kyh/N9Vday7v73xmFW1mmQ1Sfbv33+h8QMAwGBTFcWb2Jfk8XXba0le1d23JElV/WKSr52rIE6S7j6S5EiSLC8v94A4AABgkCFFcZ1j7DvFbXff8ZwHqFpJsnLgwIEBYQAAwDBDVp9YS3Lluu0rkjw5LBwAALj4hhTFx5NcU1VXV9XeJDcluWcrB+juo929urS0NCAMAAAYZtol2e5Mcn+Sa6tqrapu7u5nktyS5N4kJ5Pc3d0Pb+XkVbVSVUdOnz691bgBAGBmpl194tAm48eSHLvQk3f30SRHl5eX33mhxwAAgKE85hkAgNGba1GsfQIAgEUw16LYjXYAACwCM8UAAIyemWIAAEbPjXYAAIyeohgAgNHTUwwAwOjpKQYAYPS0TwAAMHqKYgAARk9PMQAAo6enGACA0dM+AQDA6CmKAQAYPUUxAACjpygGAGD0rD4BAMDoWX0CAIDR0z4BAMDoKYoBABg9RTEAAKOnKAYAYPRmXhRX1Y9U1Z9W1Seq6t2zPj4AAMzaVEVxVd1eVU9X1UMbxg9W1SNVdaqqDidJd5/s7ncl+dkky7MPGQAAZmvameI7khxcP1BVe5LcluSGJNclOVRV101+9uYkf5vkr2cWKQAAbJOpiuLuvi/J1zcMX5/kVHc/2t3fTHJXkhsnn7+nu388yc/NMlgAANgOlwzYd1+Sx9dtryV5VVW9NslbkzwvybHNdq6q1SSrSbJ///4BYQAAwDBDiuI6x1h39xeSfOG5du7uI0mOJMny8nIPiAMAAAYZsvrEWpIr121fkeTJrRygqlaq6sjp06cHhAEAAMMMmSk+nuSaqro6yRNJbkry9plEtcCuOvzZc44/dusbL3IkAADMyrRLst2Z5P4k11bVWlXd3N3PJLklyb1JTia5u7sf3srJu/tod68uLS1tNe5tcdXhz37nBQDAeEw1U9zdhzYZP5bz3Ez3XKpqJcnKgQMHLvQQAAAw2JD2icG6+2iSo8vLy++cZxyzsH52WSsFAMDOMvPHPG+FG+0AAFgEcy2KF62nGACAcZprUQwAAItgrj3Fu/VGO/3FAAA7ixvtpmCJNgCA3U37BAAAo6d9Ypt5Ah4AwOKz+gQAAKOnfQIAgNFTFAMAMHpz7SkeM8u2AQAsDo95BgBg9KxTvACsUAEAMF96igEAGD09xQvMDDIAwMVhphgAgNFTFAMAMHoe87yJzVoXFsE0sWmxAACYntUndinrIAMATE/7BAAAo2f1iRGwigUAwPmZKQYAYPQUxQAAjN62FMVV9Zaq+nBVfaaq3rAd5wAAgFmZuqe4qm5P8qYkT3f3S9eNH0zy/iR7knyku2/t7k8n+XRVfV+SP0zy+dmGzSzoNQYAOGMrN9rdkeSDST52dqCq9iS5Lcnrk6wlOV5V93T3lycf+e3Jz9lBzrcOsoIZANiNpi6Ku/u+qrpqw/D1SU5196NJUlV3Jbmxqk4muTXJ57r7izOKlQVg/WMAYDca2lO8L8nj67bXJmO/kuR1Sd5WVe86145VtVpVJ6rqxFe/+tWBYQAAwIUbuk5xnWOsu/sDST5wvh27+0hVPZVkZe/eva8cGAdzoCcZANgthhbFa0muXLd9RZInp93ZY553P+0WAMBOMLQoPp7kmqq6OskTSW5K8vZpd66qlSQrBw4cGBgGO4ECGQBYVFP3FFfVnUnuT3JtVa1V1c3d/UySW5Lcm+Rkkru7++Fpj9ndR7t7dWlpaatxAwDAzGxl9YlDm4wfS3LsQk5upnh3Ot+SbgAAi2ho+8QgeorZSIsFADAPcy2KzRSTmFkGAOavunveMWR5eblPnDhx0c+rGNs51s8am00GAC5UVT3Q3csbx+c6UwzTGvI/MIpoAOC5DH2i3SBVtVJVR06fPj3PMAAAGDk32jEqZo0BgHPRPsGuoUccALhQVp9gR1MIAwCzoH2C0dJKAQCcpX0CsvmMs2IZAMZhrqtPAADAItBTDOehxQIAxkFPMUzpfDf1KZgBYGfTPgEAwOi50Q62kfYLANgZFMUwZ9tdOCvMAeC5aZ8AAGD0rD4BM7bZDXlmbAFgcc11pri7j3b36tLS0jzDAABg5PQUwwycb7k2AGDxKYphh9msDUN7BgBcODfaAQAwemaKYQ6mabcw8wsAF4+iGBaI3mQAmI+ZF8VV9eIkv5VkqbvfNuvjA89SRAPAbExVFFfV7UnelOTp7n7puvGDSd6fZE+Sj3T3rd39aJKbq+oT2xEw8NxmtVayFg4AxmLameI7knwwycfODlTVniS3JXl9krUkx6vqnu7+8qyDBLaX4heAsZtq9Ynuvi/J1zcMX5/kVHc/2t3fTHJXkhtnHB8AAGy7IT3F+5I8vm57LcmrquoHkvxukpdX1Xu7+/fOtXNVrSZZTZL9+/cPCAO42MwsA7DbDCmK6xxj3d3/keRdz7Vzdx+pqqeSrOzdu/eVA+KAXc8NdQCwvYY8vGMtyZXrtq9I8uRWDtDdR7t7dWlpaUAYAAAwzJCZ4uNJrqmqq5M8keSmJG/fygGqaiXJyoEDBwaEAVyIaVaoAICxmGqmuKruTHJ/kmuraq2qbu7uZ5LckuTeJCeT3N3dD2/l5GaKAQBYBFPNFHf3oU3GjyU5dqEnN1MM4+RGPQAWzZCe4sHMFAMAsAhm/pjnrTBTDMzLZrPVZrEBxslMMQAAozfXohgAABaB9glgKheyhNtmbQnT7v9cx9msvWGzY25HO4R2C4DdQfsEAACjp30CAIDR0z4BLLxpWiy240l882yN0JYBcHFpnwAAYPS0TwAAMHqKYgAARk9PMbBttqPP92Ief7vOtVP6hS/m0nYA86anGACA0dM+AQDA6CmKAQAYPUUxAACjpygGAGD0rD4BjN52Pw1vlucesnLFvFa9mPa8O2VVjvV2YszAuVl9AgCA0dM+AQDA6CmKAQAYPUUxAACjpygGAGD0FMUAAIzezJdkq6pLk/xJkm8m+UJ3f3zW5wAAgFmaaqa4qm6vqqer6qEN4wer6pGqOlVVhyfDb03yie5+Z5I3zzheAACYuWnbJ+5IcnD9QFXtSXJbkhuSXJfkUFVdl+SKJI9PPvat2YQJAADbZ6r2ie6+r6qu2jB8fZJT3f1oklTVXUluTLKWM4XxgzlP0V1Vq0lWk2T//v1bjRtgy7bjyXUX4/jTHHe7v9tWz7XZ092GPulvmqfGTbPvVr/DVp9cN/RJd0O+/3bFNOvjTHP87TrHdtiOnJ3v+NNcY4v2326RY0uG3Wi3L8/OCCdniuF9ST6Z5Ker6kNJjm62c3cf6e7l7l6+/PLLB4QBAADDDLnRrs4x1t39X0l+aaoDVK0kWTlw4MCAMAAAYJghM8VrSa5ct31Fkie3coDuPtrdq0tLSwPCAACAYYYUxceTXFNVV1fV3iQ3JblnKweoqpWqOnL69OkBYQAAwDDTLsl2Z5L7k1xbVWtVdXN3P5PkliT3JjmZ5O7ufngrJzdTDADAIph29YlDm4wfS3LsQk+upxgAgEUw18c8mykGAGARVHfPO4ZU1VeT/NscTv2CJF+bw3nZPnK6+8jp7iOnu4+c7j67Oac/1N3/bz3ghSiK56WqTnT38rzjYHbkdPeR091HTncfOd19xpjTubZPAADAIlAUAwAwemMvio/MOwBmTk53HzndfeR095HT3Wd0OR11TzEAACRmigEAYLxFcVUdrKpHqupUVR2edzxMr6oeq6ovVdWDVXViMvb9VfVXVfXPkz+/b93n3zvJ8yNV9RPzi5yzqur2qnq6qh5aN7blHFbVKyd/F05V1Qeqqi72d2HTfL6vqp6YXKcPVtVPrvuZfC64qrqyqv6mqk5W1cNV9auTcdfpDnWenLpWz+ru0b2S7EnyL0lenGRvkn9Ict284/KaOn+PJXnBhrE/SHJ48v5wkt+fvL9ukt/nJbl6kvc98/4OY38leU2SVyR5aEgOk/x9kh9LUkk+l+SGeX+3Mb42yef7kvz6OT4rnzvgleRFSV4xeX9Zkn+a5M51ukNf58mpa3XyGutM8fVJTnX3o939zSR3JblxzjExzI1JPjp5/9Ekb1k3fld3/093/2uSUzmTf+aou+9L8vUNw1vKYVW9KMn3dvf9feZf6Y+t24eLaJN8bkY+d4Dufqq7vzh5/40kJ5Psi+t0xzpPTjczupyOtSjel+TxddtrOf9fDBZLJ/l8VT1QVauTsRd291PJmQs/yQ9OxuV659hqDvdN3m8cZ3HcUlX/OGmvOPtrdvncYarqqiQvT/J3cZ3uChtymrhWk4y3KD5X74tlOHaOV3f3K5LckOQ9VfWa83xWrne+zXIot4vtQ0l+OMnLkjyV5I8m4/K5g1TV85P8RZJf6+7/PN9HzzEmrwvoHDl1rU6MtSheS3Lluu0rkjw5p1jYou5+cvLn00k+lTPtEF+Z/Eonkz+fnnxcrneOreZwbfJ+4zgLoLu/0t3f6u5vJ/lwnm1bks8doqq+O2eKp4939ycnw67THexcOXWtPmusRfHxJNdU1dVVtTfJTUnumXNMTKGqLq2qy86+T/KGJA/lTP7eMfnYO5J8ZvL+niQ3VdXzqurqJNfkzA0CLJ4t5XDyq9tvVNWPTu58/oV1+zBnZwuniZ/Kmes0kc8dYZKDP0tysrv/eN2PXKc71GY5da0+65J5BzAP3f1MVd2S5N6cWYni9u5+eM5hMZ0XJvnUZPWXS5L8eXf/ZVUdT3J3Vd2c5N+T/EySdPfDVXV3ki8neSbJe7r7W/MJnbOq6s4kr03ygqpaS/I7SW7N1nP47iR3JPmenLkD+nMX8WswsUk+X1tVL8uZX6s+luSXE/ncQV6d5OeTfKmqHpyM/WZcpzvZZjk95Fo9wxPtAAAYvbG2TwAAwHcoigEAGD1FMQAAo6coBgBg9BTFAACMnqIYAIDRUxQDADB6imIAAEbvfwFP1mJFkTh0DQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -503,12 +594,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQMklEQVR4nO3dfYil91UH8O9x4xZp46K2lbLJmtRNi8E/+jKkvoD0j1Y3tmPqe1bxjZC10oj+Ibi+gP1HrIKixaisGtJCTQj1LYtbo4glCEF3I9UmDdE1RjNNaFILYxExpB7/2Jt2Ou5s793nzj535vl8YNh7f3Pvc8/sybM5/OY856nuDgAATNkXjR0AAACMTVEMAMDkKYoBAJg8RTEAAJOnKAYAYPIUxQAATN5VY354Va0nWb/66qtvf81rXjNmKAAATMDDDz/8ye5+xfb1WoU5xWtra33u3LmxwwAAYJ+rqoe7e237uvYJAAAmT1EMAMDkKYoBAJi8UYviqlqvqlObm5tjhgEAwMSNWhR39+nuPnHo0KExwwAAYOJGHck2tutO/tnnPX/yPW8bKRIAAMakpxgAgMlTFAMAMHmKYgAAJs/0CQAAJs/0CQAAJk/7BAAAk6coBgBg8hTFAABMnqIYAIDJ25WiuKpeWlUPV9Xbd+P4AACwTHMVxVV1V1U9W1WPbFs/VlWPV9X5qjq55Vs/neS+ZQYKAAC7Zd6d4ruTHNu6UFUHktyZ5OYkNyY5XlU3VtVbknwsySeWGCcAAOyaq+Z5UXc/WFXXbVu+Kcn57n4iSarq3iS3JHlZkpfmQqH831V1prv/d2kRAwDAks1VFO/gcJKntjzfSPKm7r4jSarqh5N8cqeCuKpOJDmRJEeOHBkQBgAADDOkKK6LrPVnH3Tffak3d/epqnomyfrBgwffOCAOAAAYZMj0iY0k1255fk2Spxc5gNs8AwCwCoYUxWeT3FBV11fVwSS3Jrl/kQNU1XpVndrc3BwQBgAADDPvSLZ7kjyU5LVVtVFVt3X3C0nuSPJAkseS3Nfdjy7y4XaKAQBYBfNOnzi+w/qZJGcu98Oraj3J+tGjRy/3EAAAMNiot3m2UwwAwCoYtSjWUwwAwCqwUwwAwOSNWhQDAMAq0D4BAMDkaZ8AAGDytE8AADB52icAAJg87RMAAEye9gkAACZPUQwAwOTpKQYAYPL0FAMAMHnaJwAAmDxFMQAAk6coBgBg8hTFAABMnukTAABMnukTAABMnvYJAAAmT1EMAMDkKYoBAJg8RTEAAJOnKAYAYPKWXhRX1ddU1e9U1Qer6seWfXwAAFi2uYriqrqrqp6tqke2rR+rqser6nxVnUyS7n6su9+Z5HuSrC0/ZAAAWK55d4rvTnJs60JVHUhyZ5Kbk9yY5HhV3Tj73rcl+Zskf7W0SAEAYJfMVRR394NJPrVt+aYk57v7ie5+Psm9SW6Zvf7+7v6GJN+/0zGr6kRVnauqc88999zlRQ8AAEtw1YD3Hk7y1JbnG0neVFVvTvIdSV6S5MxOb+7uU0lOJcna2loPiAMAAAYZUhTXRda6uz+c5MNzHaBqPcn60aNHB4QBAADDDJk+sZHk2i3Pr0ny9CIH6O7T3X3i0KFDA8IAAIBhhuwUn01yQ1Vdn+TjSW5N8n2LHGAv7hRfd/LPPvv4yfe8bcRIAABYlnlHst2T5KEkr62qjaq6rbtfSHJHkgeSPJbkvu5+dJEPt1MMAMAqmGunuLuP77B+Jpe4mO4L2Ys7xVvZNQYA2B9Gvc2znWIAAFbBqEVxVa1X1anNzc0xwwAAYOKGXGg3WHefTnJ6bW3t9jHj+EK2tknM8xqtFAAAe8uoO8UAALAKtE8AADB5LrQDAGDytE8AADB52icAAJg80yd2gUkUAAB7i/YJAAAmT1EMAMDk6SkGAGDyjGQDAGDytE8AADB5o06fmAKTKAAAVp+dYgAAJs9O8Q627vDuxjHtGgMArA7TJwAAmDzTJwAAmDztEyPRSgEAsDoUxStAgQwAMC7TJwAAmDw7xStmp11ju8kAALtnV4riqnpHkrcleWWSO7v7L3bjc/a73RgLBwDA/zd3+0RV3VVVz1bVI9vWj1XV41V1vqpOJkl3/0l3357kh5N871IjBgCAJVtkp/juJL+Z5P0vLlTVgSR3Jnlrko0kZ6vq/u7+2OwlPz/7PkuklQIAYLnm3inu7geTfGrb8k1Jznf3E939fJJ7k9xSF/xykg91998vL1wAAFi+odMnDid5asvzjdnajyd5S5Lvqqp3XuyNVXWiqs5V1bnnnntuYBgAAHD5hl5oVxdZ6+5+b5L3XuqN3X0qyakkWVtb64FxTNY8F+NpsQAAuLShRfFGkmu3PL8mydPzvrmq1pOsHz16dGAYzGunIlrhDABM2dD2ibNJbqiq66vqYJJbk9w/PCwAALhyqnu+zoWquifJm5O8PMknkvxCd/9+VX1rkl9PciDJXd39i4sGsba21ufOnVv0bYOZA3xxdo0BgP2qqh7u7rXt63O3T3T38R3WzyQ5c5lBaZ8AAGB0o97mubtPJzm9trZ2+5hxcGnmIgMA+92oRTGrSVsJADA1Qy+0G6Sq1qvq1Obm5phhAAAwcdonWIiRbgDAfmSnGACAyRu1KO7u09194tChQ2OGAQDAxLnQjl01z+QK0y0AgLGNWhSbU7x/LDqxwoQLAGCVuNCOlWLXGAAYg/YJrhi7wwDAqhr1QjsAAFgFimIAACbPhXbsCXqNAYDd5EI79jR32AMAlsGFdqwsF+YBAFeKoph9SbsFALAIRTHk8opohTcA7B+mTwAAMHmjFsVVtV5VpzY3N8cMAwCAiTN9gj1n0QvwrkSbg1YKANjbtE8AADB5imIAACbP9AmYk7nJALB/KYphm2X2Bw+5454+ZQC4cpZeFFfVq5P8XJJD3f1dyz4+7DeKXwAY31xFcVXdleTtSZ7t7q/dsn4syW8kOZDk97r7Pd39RJLbquqDuxEwDLFoAXo5LRPaLABg75l3p/juJL+Z5P0vLlTVgSR3Jnlrko0kZ6vq/u7+2LKDhN2geAUAXjTX9InufjDJp7Yt35TkfHc/0d3PJ7k3yS1Ljg8AAHbdkJ7iw0me2vJ8I8mbquorkvxiktdX1c909y9d7M1VdSLJiSQ5cuTIgDBg/9N3DAC7a0hRXBdZ6+7+jyTv/EJv7u5TVfVMkvWDBw++cUAcMFlDplsAAJ8z5OYdG0mu3fL8miRPL3KA7j7d3ScOHTo0IAwAABhmyE7x2SQ3VNX1ST6e5NYk37fIAapqPcn60aNHB4QBXA4tGQDwOXPtFFfVPUkeSvLaqtqoqtu6+4UkdyR5IMljSe7r7kcX+XA7xQAArIK5doq7+/gO62eSnLncD7dTzFRdyXFwu7EjbJcZgP1mSE/xYHaKAQBYBUu/zfMi7BTD59vtHeQhx7/SNzuxGw3AlWSnGACAyRu1KAYAgFWgfQL2mN1oY9CqAMDUaZ8AAGDytE8AADB52idgH7rSkyKWZZ6452n12Ok4q9Iaol0FYPVonwAAYPK0TwAAMHmKYgAAJk9PMbCjob3JO/XOrkJP7Tw/26r3+67C3yPAfqGnGACAydM+AQDA5CmKAQCYPEUxAACTpygGAGDyTJ8ABtk+xWHRu8wNmXCx6HuX9Vk7TdK4lCHTIXZ7ysRuTAkxGQPYbtX/XTB9AgCAydM+AQDA5CmKAQCYPEUxAACTpygGAGDyFMUAAEze0keyVdVLk/xWkueTfLi7P7DszwAAgGWaa6e4qu6qqmer6pFt68eq6vGqOl9VJ2fL35Hkg919e5JvW3K8AACwdPO2T9yd5NjWhao6kOTOJDcnuTHJ8aq6Mck1SZ6avewzywkTAAB2z1ztE939YFVdt235piTnu/uJJKmqe5PckmQjFwrjj+QSRXdVnUhyIkmOHDmyaNzAihpy17hVsxt34Zv3WIveGXDR4y/r9Yse81J3sdqNu10t6259q34nrp3ME/cq/GyrEMO89lKsu2E///xDLrQ7nM/tCCcXiuHDSf4oyXdW1W8nOb3Tm7v7VHevdffaK17xigFhAADAMEMutKuLrHV3/1eSH5nrAFXrSdaPHj06IAwAABhmyE7xRpJrtzy/JsnTixygu09394lDhw4NCAMAAIYZUhSfTXJDVV1fVQeT3Jrk/kUOUFXrVXVqc3NzQBgAADDMvCPZ7knyUJLXVtVGVd3W3S8kuSPJA0keS3Jfdz+6yIfbKQYAYBXMO33i+A7rZ5KcudwP11MMAMAqGPU2z3aKAQBYBdXdY8eQqnouyb+N8NEvT/LJET6Xyydne4t87S3ytbfI194iX6vjq7r7/80DXomieCxVda6718aOg/nJ2d4iX3uLfO0t8rW3yNfqG7V9AgAAVoGiGACAyZt6UXxq7ABYmJztLfK1t8jX3iJfe4t8rbhJ9xQDAEBipxgAAKZbFFfVsap6vKrOV9XJsePhgqp6sqo+WlUfqapzs7Uvr6q/rKp/nv35ZVte/zOzHD5eVd8yXuTTUFV3VdWzVfXIlrWF81NVb5zl+XxVvbeq6kr/LFOwQ77eXVUfn51jH6mqb93yPfkaUVVdW1V/XVWPVdWjVfUTs3Xn2Aq6RL6cY3tVd0/uK8mBJP+S5NVJDib5hyQ3jh2Xr06SJ5O8fNvaryQ5OXt8Mskvzx7fOMvdS5JcP8vpgbF/hv38leSbkrwhySND8pPk75J8fZJK8qEkN4/9s+3Hrx3y9e4kP3WR18rX+Pl6VZI3zB5fneSfZnlxjq3g1yXy5Rzbo19T3Sm+Kcn57n6iu59Pcm+SW0aOiZ3dkuR9s8fvS/KOLev3dvf/dPe/JjmfC7lll3T3g0k+tW15ofxU1auSfGl3P9QX/m/w/i3vYYl2yNdO5Gtk3f1Md//97PGnkzyW5HCcYyvpEvnaiXytuKkWxYeTPLXl+UYu/R8yV04n+YuqeriqTszWvrK7n0ku/COU5JWzdXlcDYvm5/Ds8fZ1rpw7quofZ+0VL/4qXr5WSFVdl+T1Sf42zrGVty1fiXNsT5pqUXyxXh1jOFbDN3b3G5LcnORdVfVNl3itPK62nfIjb+P67SRfneR1SZ5J8quzdflaEVX1siR/mOQnu/s/L/XSi6zJ2RV2kXw5x/aoqRbFG0mu3fL8miRPjxQLW3T307M/n03yx7nQDvGJ2a+XMvvz2dnL5XE1LJqfjdnj7etcAd39ie7+THf/b5LfzedajuRrBVTVF+dCgfWB7v6j2bJzbEVdLF/Osb1rqkXx2SQ3VNX1VXUwya1J7h85psmrqpdW1dUvPk7yzUkeyYXc/NDsZT+U5E9nj+9PcmtVvaSqrk9yQy5crMCVtVB+Zr/+/XRVfd3sCusf3PIedtmLxdXMt+fCOZbI1+hmf7+/n+Sx7v61Ld9yjq2gnfLlHNu7rho7gDF09wtVdUeSB3JhEsVd3f3oyGGRfGWSP55NorkqyR90959X1dkk91XVbUn+Pcl3J0l3P1pV9yX5WJIXkryruz8zTujTUFX3JHlzkpdX1UaSX0jyniyenx9LcneSL8mFK60/dAV/jMnYIV9vrqrX5cKvZ59M8qOJfK2Ib0zyA0k+WlUfma39bJxjq2qnfB13ju1N7mgHAMDkTbV9AgAAPktRDADA5CmKAQCYPEUxAACTpygGAGDyFMUAAEyeohgAgMlTFAMAMHn/B7v3csLxaUtkAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQN0lEQVR4nO3df6zdd1kH8PdjZ4kZ80bdIKRbXbFjsfEPftwMlYTsD9BOuA4RdcUomGUVQo3+YWJRE/jHOEw0kTAxVZpBglsWBG1DcRgjWUwWbUemrGvm6pzusoUOSSoxxmXw+EfP4HLpLef2nHvPuff7eiU3Pedzz/l+n9tn3+7Jc5/z+VZ3BwAAhuy7Zh0AAADMmqIYAIDBUxQDADB4imIAAAZPUQwAwOApigEAGLwrZnnyqlpKsnTVVVfd8YpXvGKWoQAAMAAPPfTQl7v7mtXrNQ/7FC8uLvapU6dmHQYAANtcVT3U3Yur141PAAAweIpiAAAGb6ZFcVUtVdWR8+fPzzIMAAAGbqZFcXcf7+6DCwsLswwDAICBMz4BAMDgzXRLtlm7/vCnv+X5k3e+aUaRAAAwSzrFAAAMnqIYAIDBs/sEAACDZ/cJAAAGz/gEAACDpygGAGDwFMUAAAyeohgAgMFTFAMAMHgbUhRX1ZVV9VBVvXkjjg8AANM0VlFcVUer6lxVPbJqfX9VPVZVZ6vq8Ipv/VaS+6YZKAAAbJRxO8V3J9m/cqGqdiS5K8ktSfYlOVBV+6rqDUkeTfKlKcYJAAAb5opxXtTdD1TV9auWb0pytrufSJKqujfJrUlenOTKXCiU/7eqTnT316cWMQAATNlYRfEadiV5asXz5SSv7e5DSVJV70zy5bUK4qo6mORgkuzevXuCMAAAYDKTFMV1kbX+xoPuuy/15u4+UlXPJFnauXPnayaIAwAAJjLJ7hPLSa5b8fzaJE+v5wDdfby7Dy4sLEwQBgAATGaSovhkkhuqak9V7UxyW5Jj6zlAVS1V1ZHz589PEAYAAExm3C3Z7knyYJIbq2q5qm7v7ueTHEpyf5IzSe7r7tPrOblOMQAA82Dc3ScOrLF+IsmJyz15VS0lWdq7d+/lHgIAACY209s86xQDADAPZloUmykGAGAe6BQDADB4My2KAQBgHhifAABg8IxPAAAweMYnAAAYPOMTAAAMnvEJAAAGz/gEAACDpygGAGDwzBQDADB4ZooBABg84xMAAAyeohgAgMFTFAMAMHiKYgAABs/uEwAADJ7dJwAAGDzjEwAADJ6iGACAwVMUAwAweIpiAAAGT1EMAMDgTb0orqofrqo/rapPVNW7p318AACYtrGK4qo6WlXnquqRVev7q+qxqjpbVYeTpLvPdPe7kvx8ksXphwwAANM1bqf47iT7Vy5U1Y4kdyW5Jcm+JAeqat/oez+d5B+S/N3UIgUAgA0yVlHc3Q8k+cqq5ZuSnO3uJ7r7uST3Jrl19Ppj3f3jSX5xrWNW1cGqOlVVp5599tnLix4AAKbgigneuyvJUyueLyd5bVXdnOStSV6U5MRab+7uI0mOJMni4mJPEAcAAExkkqK4LrLW3f25JJ8b6wBVS0mW9u7dO0EYAAAwmUl2n1hOct2K59cmeXo9B+ju4919cGFhYYIwAABgMpN0ik8muaGq9iT5YpLbkrx9PQfYip3i6w9/+huPn7zzTTOMBACAaRl3S7Z7kjyY5MaqWq6q27v7+SSHktyf5EyS+7r79MaFCgAAG2OsTnF3H1hj/UQu8WG6MY57PMnxxcXFOy73GLOkawwAsD24zTMAAIM306K4qpaq6sj58+dnGQYAAAM3yQftJrZVxidWjkmM8xqjFAAAW4tOMQAAgzfTotg+xQAAzAMftAMAYPAUxQAADJ6ZYgAABs/uExvAThQAAFuL8QkAAAZPUQwAwOCZKQYAYPDsUwwAwOAZnwAAYPBmuvvEENiJAgBg/ukUAwAweDrFa1jZ4d2IY+oaAwDMD7tPAAAweHafAABg8IxPzIhRCgCA+aEongMKZACA2bL7BAAAg6dTPGfW6hrrJgMAbJwNKYqr6i1J3pTkJUnu6u7PbsR5truN2BYOAIBvN/b4RFUdrapzVfXIqvX9VfVYVZ2tqsNJ0t1/1d13JHlnkl+YasQAADBl6+kU353kQ0k+9sJCVe1IcleSNyZZTnKyqo5196Ojl/zu6PtMkVEKAIDpGrtT3N0PJPnKquWbkpzt7ie6+7kk9ya5tS74QJLPdPfnpxcuAABM36S7T+xK8tSK58ujtV9L8oYkb6uqd13sjVV1sKpOVdWpZ599dsIwAADg8k36Qbu6yFp39weTfPBSb+zuI0mOJMni4mJPGMdgjfNhPCMWAACXNmlRvJzkuhXPr03y9LhvrqqlJEt79+6dMAzGtVYRrXAGAIZs0vGJk0luqKo9VbUzyW1Jjk0eFgAAbJ6xO8VVdU+Sm5NcXVXLSd7X3R+pqkNJ7k+yI8nR7j497jG7+3iS44uLi3esL+yNYV9gAIBhqu7ZjfOuGJ+44/HHH9/08yuCL84oBQCwXVXVQ929uHp90vGJiXT38e4+uLCwMMswAAAYuA25zfO4fNBuPl2qg66LDABsRzrFAAAM3kyLYgAAmAfGJ1gX+xwDANuR8QkAAAZvpp1itr+VnWXdZABgXhmfYOYUzgDArM20KJ63O9oxHePcFMWNUwCAeTLTO9q9YHFxsU+dOrXp51WYzTddYwBg2ubyjnYAADAPFMUAAAzeTIviqlqqqiPnz5+fZRgAAAycD9qxJYyzQ4VdLACAy2WfYuaWXSwAgM2iKGZb0jUGANZDUQy5vCJa4Q0A24fdJwAAGDy7TwAAMHh2n4ApMEoBAFubmWK2HDtOAADTpihm29PFBQC+E0UxjEmHGgC2L0UxrDLNzvIkx9LhBoDNM/WiuKpenuR3kix099umfXzYqtYqchW/ADB7YxXFVXU0yZuTnOvuH1mxvj/JHyfZkeTPu/vO7n4iye1V9YmNCBgmsRkFqDELANh6xu0U353kQ0k+9sJCVe1IcleSNyZZTnKyqo5196PTDhI2wjjFqwIXAIZhrJt3dPcDSb6yavmmJGe7+4nufi7JvUlunXJ8AACw4SaZKd6V5KkVz5eTvLaqfiDJ7yV5VVW9t7t//2JvrqqDSQ4mye7duycIA7Y/c8cAsLEmKYrrImvd3f+V5F3f6c3dfaSqnkmytHPnztdMEAcMlmIZAKZjrPGJNSwnuW7F82uTPL2eA3T38e4+uLCwMEEYAAAwmUk6xSeT3FBVe5J8McltSd6+ngNU1VKSpb17904QBpCsv2usywwA3zRWp7iq7knyYJIbq2q5qm7v7ueTHEpyf5IzSe7r7tPrOblOMQAA82CsTnF3H1hj/USSE5d7cp1ihmozt3rbiI6wLjMA280kM8UT0ykGAGAeTP02z+uhUwzfaqM7yJMcf7NvZKIbDcBm0ikGAGDwZloUAwDAPDA+AVvMRowxGFUAYOiMTwAAMHjGJwAAGDzjE7ANbfZOEdMyTtzjjHqsdZx5GQ0xrgIwf4xPAAAweMYnAAAYPEUxAACDZ6YY2DBrzc7Ow0ztOPPL8z7vOw9/jwDbhZliAAAGz/gEAACDpygGAGDwFMUAAAyeohgAgMGz+wSwpvXeYS5Z/13mJrn73nrfO61zrbWTxqVMsjvERu8ysRG7hNgZA1ht3v9dsPsEAACDZ3wCAIDBUxQDADB4imIAAAZPUQwAwOApigEAGLypb8lWVVcm+ZMkzyX5XHd/fNrnAACAaRqrU1xVR6vqXFU9smp9f1U9VlVnq+rwaPmtST7R3Xck+ekpxwsAAFM37vjE3Un2r1yoqh1J7kpyS5J9SQ5U1b4k1yZ5avSyr00nTAAA2DhjjU909wNVdf2q5ZuSnO3uJ5Kkqu5NcmuS5VwojB/OJYruqjqY5GCS7N69e71xA3NqkrvGzZuNuAvfuMda750B13v8ab1+vce81F2sNuJuV9O6W9+834lrLePEPQ8/2zzEMK6tFOtG2M4//yQftNuVb3aEkwvF8K4kn0zys1X14STH13pzdx/p7sXuXrzmmmsmCAMAACYzyQft6iJr3d3/k+RXxjpA1VKSpb17904QBgAATGaSTvFykutWPL82ydPrOUB3H+/ugwsLCxOEAQAAk5mkKD6Z5Iaq2lNVO5PcluTYeg5QVUtVdeT8+fMThAEAAJMZd0u2e5I8mOTGqlquqtu7+/kkh5Lcn+RMkvu6+/R6Tq5TDADAPBh394kDa6yfSHLick9uphgAgHkw09s86xQDADAPqrtnHUOq6tkk/zGDU1+d5MszOC+XT862FvnaWuRra5GvrUW+5scPdve37Qc8F0XxrFTVqe5enHUcjE/Othb52lrka2uRr61FvubfTMcnAABgHiiKAQAYvKEXxUdmHQDrJmdbi3xtLfK1tcjX1iJfc27QM8UAAJDoFAMAwHCL4qraX1WPVdXZqjo863i4oKqerKovVNXDVXVqtPb9VfW3VfX46M/vW/H6945y+FhV/eTsIh+GqjpaVeeq6pEVa+vOT1W9ZpTns1X1waqqzf5ZhmCNfL2/qr44usYerqqfWvE9+Zqhqrquqv6+qs5U1emq+vXRumtsDl0iX66xraq7B/eVZEeSf0vy8iQ7k/xzkn2zjstXJ8mTSa5etfYHSQ6PHh9O8oHR432j3L0oyZ5RTnfM+mfYzl9JXp/k1UkemSQ/Sf4pyY8lqSSfSXLLrH+27fi1Rr7en+Q3L/Ja+Zp9vl6W5NWjx1cl+ddRXlxjc/h1iXy5xrbo11A7xTclOdvdT3T3c0nuTXLrjGNibbcm+ejo8UeTvGXF+r3d/X/d/e9JzuZCbtkg3f1Akq+sWl5XfqrqZUm+t7sf7Av/N/jYivcwRWvkay3yNWPd/Ux3f370+KtJziTZFdfYXLpEvtYiX3NuqEXxriRPrXi+nEv/h8zm6SSfraqHqurgaO2l3f1McuEfoSQvGa3L43xYb352jR6vXmfzHKqqfxmNV7zwq3j5miNVdX2SVyX5x7jG5t6qfCWusS1pqEXxxWZ1bMMxH17X3a9OckuS91TV6y/xWnmcb2vlR95m68NJfijJK5M8k+QPR+vyNSeq6sVJ/jLJb3T3f1/qpRdZk7NNdpF8uca2qKEWxctJrlvx/NokT88oFlbo7qdHf55L8qlcGIf40ujXSxn9eW70cnmcD+vNz/Lo8ep1NkF3f6m7v9bdX0/yZ/nmyJF8zYGq+u5cKLA+3t2fHC27xubUxfLlGtu6hloUn0xyQ1XtqaqdSW5LcmzGMQ1eVV1ZVVe98DjJTyR5JBdy847Ry96R5K9Hj48lua2qXlRVe5LckAsfVmBzrSs/o1//frWqfnT0CetfXvEeNtgLxdXIz+TCNZbI18yN/n4/kuRMd//Rim+5xubQWvlyjW1dV8w6gFno7uer6lCS+3NhJ4qj3X16xmGRvDTJp0Y70VyR5C+6+2+q6mSS+6rq9iT/meTnkqS7T1fVfUkeTfJ8kvd099dmE/owVNU9SW5OcnVVLSd5X5I7s/78vDvJ3Um+Jxc+af2ZTfwxBmONfN1cVa/MhV/PPpnkVxP5mhOvS/JLSb5QVQ+P1n47rrF5tVa+DrjGtiZ3tAMAYPCGOj4BAADfoCgGAGDwFMUAAAyeohgAgMFTFAMAMHiKYgAABk9RDADA4CmKAQAYvP8He2d3zSdsMOwAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -530,12 +621,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAs4AAADCCAYAAABZsUR+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQsklEQVR4nO3db6hl510v8O+vU6dCjQe1VcokY1InLTf4wraH1KsXEfw3qR7Tq4KJgn8IGXrvjegL4Y4o6Bu5VVCwNCpTG2JFEmPV2xk6EkUt4UKwmUitSUPsNPaSY0KTWjhXLhdzoz9fnJ14Os6ZWWf23mftP58PbGbv5+y11nPOc9bMd579W8+q7g4AAHBlrxm7AwAAsAwEZwAAGEBwBgCAAQRnAAAYQHAGAIABBGcAABjgtWMevKq2kmxdd911d7/lLW8ZsysAAKyBxx9//PPd/cZr2bYWYR3nzc3NvnDhwtjdAABgxVXV4929eS3bKtUAAIABBGcAABhg1OBcVVtVdWZnZ2fMbgAAwFWNGpy7+1x3n9rY2BizGwAAcFVKNQAAYIBRl6Mb242nP/pFrz/73u8eqScAACw6M84AADCA4AwAAANYVQMAAAawqgYAAAygVAMAAAYQnAEAYADBGQAABhCcAQBgAMEZAAAGmEtwrqrXV9XjVfU989g/AAActkHBuaruq6oXquqJS9pPVtXTVXWxqk7v+dJ/T/LQLDsKAABjGjrjfH+Sk3sbqupIknuT3JbkliR3VtUtVfXtST6V5HMz7CcAAIzqtUPe1N2PVNWNlzTfmuRidz+TJFX1YJLbk3xZktdnN0z/v6o6393/cuk+q+pUklNJcvz48WvtPwAAHIpBwXkfx5I8u+f1dpJ3dvc9SVJVP5bk85cLzUnS3WeSnEmSzc3NnqIfAAAwd9ME57pM26sBuLvvv+oOqraSbJ04cWKKbgAAwPxNs6rGdpIb9ry+PslzB9lBd5/r7lMbGxtTdAMAAOZvmuD8WJKbq+qmqjqa5I4kZw+yg6raqqozOzs7U3QDAADmb+hydA8keTTJW6tqu6ru6u6Xk9yT5OEkTyV5qLufPMjBzTgDALAshq6qcec+7eeTnL/Wg6txBgBgWYx6y20zzgAALItRg7MaZwAAloUZZwAAGGDU4AwAAMtCqQYAAAygVAMAAAZQqgEAAAMo1QAAgAGUagAAwABKNQAAYADBGQAABlDjDAAAA6hxBgCAAZRqAADAAIIzAAAMIDgDAMAAgjMAAAxgVQ0AABjAqhoAADCAUg0AABhAcAYAgAEEZwAAGEBwBgCAAQRnAAAYYObBuar+Q1X9ZlV9uKr+y6z3DwAAY3jtkDdV1X1JvifJC9399XvaTyb5tSRHkvxWd7+3u59K8p6qek2SD8yhz3Nz4+mPvvr8s+/97hF7AgDAohk643x/kpN7G6rqSJJ7k9yW5JYkd1bVLZOvfW+S/5Xkz2bWUwAAGNGg4NzdjyT5wiXNtya52N3PdPdLSR5Mcvvk/We7+5uS/PB++6yqU1V1oaouvPjii9fWewAAOCSDSjX2cSzJs3tebyd5Z1V9a5LvS/K6JOf327i7zyQ5kySbm5s9RT8AAGDupgnOdZm27u6PJfnYoB1UbSXZOnHixBTdAACA+ZtmVY3tJDfseX19kuem6w4AACymaYLzY0lurqqbqupokjuSnD3IDrr7XHef2tjYmKIbAAAwf4OCc1U9kOTRJG+tqu2ququ7X05yT5KHkzyV5KHufvIgB6+qrao6s7Ozc9B+AwDAoRpU49zdd+7Tfj5XuABwwH7PJTm3ubl597XuAwAADoNbbgMAwADTrKoxtUVeVcNdBAEA2GvUGWcXBwIAsCxGDc4uDgQAYFmYcQYAgAFcHAgAAAMIzgAAMIAaZwAAGECNMwAADKBUAwAABhj1BijLws1QAABQ4wwAAAOocQYAgAHUOAMAwACCMwAADCA4AwDAAIIzAAAMYFUNAAAYYNR1nLv7XJJzm5ubd4/Zj4OwpjMAwHpSqgEAAAMIzgAAMIDgDAAAAwjOAAAwwFyCc1W9u6o+UFUfqarvnMcxAADgMA0OzlV1X1W9UFVPXNJ+sqqerqqLVXU6Sbr7f3b33Ul+LMkPzrTHAAAwgoMsR3d/kvcn+dArDVV1JMm9Sb4jyXaSx6rqbHd/avKWn5t8fSVZmg4AYH0MnnHu7keSfOGS5luTXOzuZ7r7pSQPJrm9dv1Skj/u7r+aXXcBAGAc09Y4H0vy7J7X25O2n0jy7Ul+oKrec7kNq+pUVV2oqgsvvvjilN0AAID5mvbOgXWZtu7u9yV535U27O4zVfV8kq2jR4++Y8p+AADAXE0747yd5IY9r69P8tzQjbv7XHef2tjYmLIbAAAwX9MG58eS3FxVN1XV0SR3JDk7dOOq2qqqMzs7O1N2AwAA5mtwqUZVPZDkW5O8oaq2k/x8d3+wqu5J8nCSI0nu6+4nh+6zu88lObe5uXn3wboNJF+8sste06zyMo99AsAqGBycu/vOfdrPJzl/LQevqq0kWydOnLiWzWGlTRNgxwy/lmkEYFVNe3HgVMw4s672C5f7Bd559+EwjiFEA7DsRg3OZpxZRIcd9lYtLM+DAA7AIjDjDDM27zKJZQ2/ALDsRg3Oq8SMGFez7IF32fsPANNSqjEHQvT6ESqvbkhd90EvfHR+AXCYlGrAFQhp87HffzT8vAFYZEo1gKUlaANwmJRqAAtJ+QsAi0apBmvroMFMkFtsZp8BmDelGsDKGRKiZ3WxIgDrQ3AG1sasPjUQrgHWk+AMrLRpwvIsA7KwDbD8XjPmwatqq6rO7OzsjNkNAAC4KhcHstSmqWWFVwyZlXYxKQBKNVgZAjJjmGVA9jsMsNgEZ5aCQAEAjE1wBlhA/rMIsHhGvTgQAACWhVtus5L2qzt1wRaLxu8kwPIYdca5u89196mNjY0xuwEAAFelxnnO1CkCAKwGwZmF5SNsAGCRuDgQAAAGMOPM0jETzbKb1e/wfqVgSsQA5mPmM85V9eaq+mBVfXjW+wYAgLEMCs5VdV9VvVBVT1zSfrKqnq6qi1V1Okm6+5nuvmsenV0lN57+6KsPAAAW39BSjfuTvD/Jh15pqKojSe5N8h1JtpM8VlVnu/tTs+7kqhCSgWuh9AJgMQyace7uR5J84ZLmW5NcnMwwv5TkwSS3z7h/AACwEKa5OPBYkmf3vN5O8s6q+qokv5jkbVX1M939Py63cVWdSnIqSY4fPz5FNwDWxzw+uTKjDTDMNMG5LtPW3f0PSd5ztY27+0xVPZ9k6+jRo++Yoh8AHNCQAH7QQC2AA6tumlU1tpPcsOf19UmeO8gO3HIbAIBlMc2M82NJbq6qm5L8fZI7kvzQQXZQVVtJtk6cODFFNwBY1ouPzVIDy2TocnQPJHk0yVuraruq7urul5Pck+ThJE8leai7nzzIwc04AwCwLAbNOHf3nfu0n09y/loPbsb531vl2ZdV/t5gUbmYEGB2Zn7nwIMw4wwAwLKYpsZ5amac15cZK1gu+81cL2ttNcC1MOMMAAADjBqcAQBgWSjVYHTKNmB9HEZph79TgHlRqgEAAAMo1QAAgAGUaiwAV6X/Gz8LGNeszsFrKZdQYgEsOqUaAAAwgFINAAAYQHAGAIAB1DgzV2qWgWv5e2C/bfbWPs+qJnrIftRfA4kaZwAAGESpBgAADCA4AwDAAIIzAAAMIDgDAMAAVtVYYEOuKh/TovcPWB8HXbljrBV/Vnl1jjG/t1X+ubJYrKoBAAADKNUAAIABBGcAABhAcAYAgAEEZwAAGEBwBgCAAWa+HF1VvT7Jryd5KcnHuvt3Z30MAAA4bINmnKvqvqp6oaqeuKT9ZFU9XVUXq+r0pPn7kny4u+9O8r0z7i8AAIxiaKnG/UlO7m2oqiNJ7k1yW5JbktxZVbckuT7Js5O3/fNsugkAAOMaVKrR3Y9U1Y2XNN+a5GJ3P5MkVfVgktuTbGc3PH8iVwjmVXUqyakkOX78+EH7vdaG3CFpmrv6XbrtQe/CNNYduYDVN+87BA55/35/Bw9pv9KxhuxrHg56rFn9TFf5Dn+HfSfDZfkZr8IdHqe5OPBY/m1mOdkNzMeS/GGS76+q30hybr+Nu/tMd2929+Yb3/jGKboBAADzN83FgXWZtu7u/5vkxwftoGorydaJEyem6AYAAMzfNDPO20lu2PP6+iTPHWQH3X2uu09tbGxM0Q0AAJi/aYLzY0lurqqbqupokjuSnD3IDqpqq6rO7OzsTNENAACYv6HL0T2Q5NEkb62q7aq6q7tfTnJPkoeTPJXkoe5+8iAHN+MMAMCyGLqqxp37tJ9Pcv5aD67GGQCAZTHqLbfNOAMAsCyqu8fuQ6rqxST/e4RDvyHJ50c4LuMz9uvJuK8n476+jP16utq4f213X9NayAsRnMdSVRe6e3PsfnD4jP16Mu7rybivL2O/nuY57qOWagAAwLIQnAEAYIB1D85nxu4AozH268m4ryfjvr6M/Xqa27ivdY0zAAAMte4zzgAAMMjaBueqOllVT1fVxao6PXZ/mF5Vfbaq/qaqPlFVFyZtX1lVf1pVn578+RV73v8zk/F/uqq+a0/7Oyb7uVhV76uqGuP74fKq6r6qeqGqntjTNrNxrqrXVdXvTdr/sqpuPMzvj/3tM/a/UFV/PznvP1FV79rzNWO/5Krqhqr6i6p6qqqerKqfnLQ751fcFcZ+3HO+u9fukeRIks8keXOSo0n+OsktY/fLY+px/WySN1zS9stJTk+en07yS5Pnt0zG/XVJbpr8PhyZfO3jSf5jkkryx0luG/t78/iiMf2WJG9P8sQ8xjnJf03ym5PndyT5vbG/Z48rjv0vJPnpy7zX2K/AI8mbkrx98vy6JH87GVvn/Io/rjD2o57z6zrjfGuSi939THe/lOTBJLeP3Cfm4/Ykvz15/ttJ3r2n/cHu/qfu/rskF5PcWlVvSvLl3f1o755JH9qzDQugux9J8oVLmmc5znv39eEk3+ZTh8Wwz9jvx9ivgO5+vrv/avL8H5M8leRYnPMr7wpjv59DGft1Dc7Hkjy75/V2rjwYLIdO8idV9XhVnZq0fU13P5/snoRJvnrSvt/vwLHJ80vbWWyzHOdXt+nul5PsJPmqufWcWbinqj45KeV45SN7Y79iJh+jvy3JX8Y5v1YuGftkxHN+XYPz5f43YXmR5ffN3f32JLcl+W9V9S1XeO9+vwN+N1bLtYyz34Hl8htJvi7JNyR5PsmvTNqN/Qqpqi9L8gdJfqq7/8+V3nqZNuO+xC4z9qOe8+sanLeT3LDn9fVJnhupL8xIdz83+fOFJH+U3ZKcz00+psnkzxcmb9/vd2B78vzSdhbbLMf51W2q6rVJNjK8PIBD1t2f6+5/7u5/SfKB7J73ibFfGVX1JdkNTr/b3X84aXbOr4HLjf3Y5/y6BufHktxcVTdV1dHsFoSfHblPTKGqXl9V173yPMl3Jnkiu+P6o5O3/WiSj0yen01yx+SK2puS3Jzk45OP/P6xqr5xUuf0I3u2YXHNcpz37usHkvz5pC6OBfRKeJr4z9k97xNjvxImY/TBJE9196/u+ZJzfsXtN/ajn/NjXzU51iPJu7J7heZnkvzs2P3xmHo835zdq2n/OsmTr4xpdmuV/izJpyd/fuWebX52Mv5PZ8/KGUk2JyfiZ5K8P5MbBXksxiPJA9n9eO7/Z3e24K5ZjnOSL03y+9m9sOTjSd489vfsccWx/50kf5Pkk5N/BN9k7FfnkeQ/Zfej808m+cTk8S7n/Oo/rjD2o57z7hwIAAADrGupBgAAHIjgDAAAAwjOAAAwgOAMAAADCM4AADCA4AwAAAMIzgAAMIDgDAAAA/wr/1q3Qz+VIrIAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAs4AAADCCAYAAABZsUR+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQoklEQVR4nO3dfahl91kv8O/TqVOhxsPVVimTjEnvpMXBP7Q9pL4hgi930nqMLwUzCr4QMlSN6B+CIwr6jxgv3Au3GJXpbYiKJMb6lqFToqglCMEmkVoTh+g0RnJMaFoLo4hYo49/nJ14Os6ZrHP23mftl88HNmfv39lr7eecZ6+Z5/z2s36rujsAAMC1vWbsAAAAYBkonAEAYACFMwAADKBwBgCAARTOAAAwgMIZAAAGeO2YL15VW0m2rrvuujvf8pa3jBkKAABr4IknnvhUd7/xINvWIqzjvLm52Y8//vjYYQAAsOKq6onu3jzItlo1AABgAIUzAAAMMGrhXFVbVXXu8uXLY4YBAACvatTCubvPd/eZjY2NMcMAAIBXpVUDAAAGGHU5urHdePaDn/X42bvfNVIkAAAsOjPOAAAwgMIZAAAGsKoGAAAMYFUNAAAYQKsGAAAMoHAGAIABFM4AADCAwhkAAAZQOAMAwABzKZyr6vVV9URVfcs89g8AAIdtUOFcVfdW1YtV9eQV46eq6umqulRVZ3d96yeSPDjLQAEAYExDZ5zvS3Jq90BVHUlyT5Jbk5xMcrqqTlbVNyb5qySfmGGcAAAwqtcOeVJ3P1JVN14xfEuSS939TJJU1QNJbkvyeUlen51i+l+q6kJ3/8eV+6yqM0nOJMnx48cPGj8AAByKQYXzHo4leW7X4+0k7+juu5Kkqr4/yaeuVjQnSXefS3IuSTY3N3uKOAAAYO6mKZzrKmOvFMDdfd+r7qBqK8nWiRMnpggDAADmb5pVNbaT3LDr8fVJnt/PDrr7fHef2djYmCIMAACYv2kK58eS3FxVN1XV0SS3J3loPzuoqq2qOnf58uUpwgAAgPkbuhzd/UkeTfLWqtquqju6+6UkdyV5OMnFJA9291PzCxUAAMYzdFWN03uMX0hy4aAv3t3nk5zf3Ny886D7AACAw+CS2wAAMMCohbMeZwAAlsWohbNVNQAAWBZmnAEAYAAzzgAAMICTAwEAYACFMwAADKDHGQAABtDjDAAAA2jVAACAARTOAAAwgB5nAAAYQI8zAAAMoFUDAAAGUDgDAMAACmcAABhA4QwAAANYVQMAAAawqgYAAAygVQMAAAZQOAMAwAAKZwAAGEDhDAAAA8y8cK6qL62qX6mqD1TVD856/wAAMIbXDnlSVd2b5FuSvNjdX7Zr/FSS/5fkSJL/3913d/fFJO+pqtcked8cYp6bG89+8JX7z979rhEjAQBg0Qydcb4vyandA1V1JMk9SW5NcjLJ6ao6Ofnetyb50yR/NLNIAQBgRIMK5+5+JMmnrxi+Jcml7n6muz+T5IEkt02e/1B3f3WS75llsAAAMJZBrRp7OJbkuV2Pt5O8o6q+Psl3JHldkgt7bVxVZ5KcSZLjx49PEQYAAMzfNIVzXWWsu/vDST78aht397kk55Jkc3Ozp4gDAADmbppVNbaT3LDr8fVJnt/PDqpqq6rOXb58eYowAABg/qYpnB9LcnNV3VRVR5PcnuSh2YQFAACLZVDhXFX3J3k0yVuraruq7ujul5LcleThJBeTPNjdT+3nxbv7fHef2djY2G/cAABwqAb1OHf36T3GL+QaJwC+mqraSrJ14sSJg+4CAAAOxaiX3DbjDADAshi1cAYAgGUxauFsVQ0AAJbFNOs4T627zyc5v7m5eeeYcVzNjWc/+Mr9Z+9+14iRAACwCMw4AwDAAE4OBACAAZwcCAAAA2jVAACAAbRqAADAAFo1AABgAIUzAAAMMOo6zsvCms4AADg5EAAABnByIAAADKDHGQAABlA4AwDAAApnAAAYQOEMAAADWFUDAAAGGHUd5+4+n+T85ubmnWPGsR/WdAYAWE9aNQAAYACFMwAADKBwBgCAARTOAAAwwFwK56r6tqp6X1X9flV98zxeAwAADtPgwrmq7q2qF6vqySvGT1XV01V1qarOJkl3/15335nk+5N810wjBgCAEexnxvm+JKd2D1TVkST3JLk1yckkp6vq5K6n/PTk+wAAsNQGr+Pc3Y9U1Y1XDN+S5FJ3P5MkVfVAktuq6mKSu5N8qLv/fEaxLhxrOgMArI9pe5yPJXlu1+PtydiPJPnGJO+uqvdcbcOqOlNVj1fV45/85CenDAMAAOZr2isH1lXGurvfm+S919qwu89V1QtJto4ePfr2KeMAAIC5mnbGeTvJDbseX5/k+aEbd/f57j6zsbExZRgAADBf0xbOjyW5uapuqqqjSW5P8tDQjatqq6rOXb58ecowAABgvga3alTV/Um+Pskbqmo7yc909/ur6q4kDyc5kuTe7n5q6D67+3yS85ubm3fuL2wg+ewTVHeb5mTVeewTAFbBflbVOL3H+IUkFw7y4lW1lWTrxIkTB9kc1sZ+V3AZs/i12gwAq2rakwOnYsYZPtteBe+yvq4iGoBVMmrhbMaZRXQYxd6qFcjzpgAHYBGYcYYZm3eRt6zFLwAsu1EL51VldoyXrVKRu0o/CwAchFaNGVFUwLXt9QflNCc++sMUgMOkVQNmwB9O+7PX70tRDMAi06oB16CQW2zyA8Bh0qoBLCSz+AAsGq0arK39FmYKucVm9hmAedOqAaycIUX0rE5WBGB9vGbsAAAAYBnocQZW2jQtNrOclTaTDbD89DgDa29Ica3HHQA9ziy1aXpZYZ4U2gCrR+HMylAgM4ZZFsjewwCLTeHMUlBQAABjUzgDLCB/LAIsHqtqsJL0l7IsvFcBlodVNVgrihQA4KBcAAUAAAbQ4zxn+hQBAFaDwpmFpa0CAFgkWjUAAGAAM84sHTPRLLtZvYf3agXTIgYwHzOfca6qN1fV+6vqA7PeNwAAjGVQ4VxV91bVi1X15BXjp6rq6aq6VFVnk6S7n+nuO+YR7Cq58ewHX7kBALD4hrZq3JfkF5P82ssDVXUkyT1JvinJdpLHquqh7v6rWQe5KhTJwEFovQBYDINmnLv7kSSfvmL4liSXJjPMn0nyQJLbZhwfAAAshGlODjyW5Lldj7eTvKOqvjDJzyX5iqr6ye7++attXFVnkpxJkuPHj08RBsD6mMcnV2a0AYaZpnCuq4x1d/9Dkve82sbdfa6qXkiydfTo0bdPEQcA+zSkAN9vQa0AB1bdNKtqbCe5Ydfj65M8v58ddPf57j6zsbExRRgAADB/08w4P5bk5qq6KcnfJ7k9yXfvZwdVtZVk68SJE1OEAcCynnxslhpYJkOXo7s/yaNJ3lpV21V1R3e/lOSuJA8nuZjkwe5+aj8vbsYZAIBlMWjGubtP7zF+IcmFg764Gef1YmYJDp+TCQFmZ+ZXDtwPM84AACyLaXqcp2bG+b9bl5mcdfk5YVXsNXO9rL3VAAdhxhkAAAYYtXAGAIBloVWD0WnbgPVxGK0d/k0B5kWrBgAADKBVAwAABtCqsQCclf5f/C5gXLM6Bg/SLqHFAlh0WjUAAGAArRoAADCAwhkAAAbQ48xc6VkGDvLvwF7b7O59nlVP9JD96L8GEj3OAAAwiFYNAAAYQOEMAAADKJwBAGAAhTMAAAxgVY0FNuSs8jEtenzA+tjvyh1jrfizyqtzjPmzrfLvlcViVQ0AABhAqwYAAAygcAYAgAEUzgAAMIDCGQAABlA4AwDAADNfjq6qXp/kl5J8JsmHu/s3Zv0aAABw2AbNOFfVvVX1YlU9ecX4qap6uqouVdXZyfB3JPlAd9+Z5FtnHC8AAIxiaKvGfUlO7R6oqiNJ7klya5KTSU5X1ckk1yd5bvK0f59NmAAAMK5BrRrd/UhV3XjF8C1JLnX3M0lSVQ8kuS3JdnaK54/mGoV5VZ1JciZJjh8/vt+419qQKyRNc1W/K7fd71WYxroiF7D65n2FwCHP3+vf4CHj13qtIfuah/2+1qx+p6t8hb/DvpLhsvyOV+EKj9OcHHgs/zWznOwUzMeS/E6S76yqX05yfq+Nu/tcd2929+Yb3/jGKcIAAID5m+bkwLrKWHf3Pyf5gUE7qNpKsnXixIkpwgAAgPmbZsZ5O8kNux5fn+T5/eygu89395mNjY0pwgAAgPmbpnB+LMnNVXVTVR1NcnuSh/azg6raqqpzly9fniIMAACYv6HL0d2f5NEkb62q7aq6o7tfSnJXkoeTXEzyYHc/tZ8XN+MMAMCyGLqqxuk9xi8kuXDQF9fjDADAshj1kttmnAEAWBbV3WPHkKr6ZJK/G+Gl35DkUyO8LuOT+/Uk7+tJ3teX3K+nV8v7l3T3gdZCXojCeSxV9Xh3b44dB4dP7teTvK8neV9fcr+e5pn3UVs1AABgWSicAQBggHUvnM+NHQCjkfv1JO/rSd7Xl9yvp7nlfa17nAEAYKh1n3EGAIBB1rZwrqpTVfV0VV2qqrNjx8P0qurZqvrLqvpoVT0+GfuCqvrDqvqbydf/sev5PznJ/9NV9b92jb99sp9LVfXeqqoxfh6urqruraoXq+rJXWMzy3NVva6qfnMy/mdVdeNh/nzsbY/c/2xV/f3kuP9oVb1z1/fkfslV1Q1V9SdVdbGqnqqqH52MO+ZX3DVyP+4x391rd0tyJMnHk7w5ydEkf5Hk5NhxuU2d12eTvOGKsf+d5Ozk/tkkvzC5f3KS99cluWnyfjgy+d5HknxVkkryoSS3jv2zuX1WTr8uyduSPDmPPCf5oSS/Mrl/e5LfHPtndrtm7n82yY9f5blyvwK3JG9K8rbJ/euS/PUkt475Fb9dI/ejHvPrOuN8S5JL3f1Md38myQNJbhs5JubjtiS/Orn/q0m+bdf4A939r939t0kuJbmlqt6U5PO7+9HeOZJ+bdc2LIDufiTJp68YnmWed+/rA0m+wacOi2GP3O9F7ldAd7/Q3X8+uf9PSS4mORbH/Mq7Ru73cii5X9fC+ViS53Y93s61k8Fy6CR/UFVPVNWZydgXd/cLyc5BmOSLJuN7vQeOTe5fOc5im2WeX9mmu19KcjnJF84tcmbhrqr62KSV4+WP7OV+xUw+Rv+KJH8Wx/xauSL3yYjH/LoWzlf7a8LyIsvva7r7bUluTfLDVfV113juXu8B743VcpA8ew8sl19O8j+TfHmSF5L8n8m43K+Qqvq8JL+d5Me6+x+v9dSrjMn7ErtK7kc95te1cN5OcsOux9cneX6kWJiR7n5+8vXFJL+bnZacT0w+psnk64uTp+/1Htie3L9ynMU2yzy/sk1VvTbJRoa3B3DIuvsT3f3v3f0fSd6XneM+kfuVUVWfk53C6Te6+3cmw475NXC13I99zK9r4fxYkpur6qaqOpqdhvCHRo6JKVTV66vqupfvJ/nmJE9mJ6/fN3na9yX5/cn9h5LcPjmj9qYkNyf5yOQjv3+qqq+c9Dl9765tWFyzzPPufb07yR9P+uJYQC8XTxPfnp3jPpH7lTDJ0fuTXOzu/7vrW475FbdX7kc/5sc+a3KsW5J3ZucMzY8n+amx43GbOp9vzs7ZtH+R5KmXc5qdXqU/SvI3k69fsGubn5rk/+nsWjkjyebkQPx4kl/M5EJBbotxS3J/dj6e+7fszBbcMcs8J/ncJL+VnRNLPpLkzWP/zG7XzP2vJ/nLJB+b/Cf4JrlfnVuSr83OR+cfS/LRye2djvnVv10j96Me864cCAAAA6xrqwYAAOyLwhkAAAZQOAMAwAAKZwAAGEDhDAAAAyicAQBgAIUzAAAMoHAGAIAB/hMS5ZdHGeKRYwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -557,12 +648,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQkklEQVR4nO3db4hl91kH8O/j1q2Q6mCbKGWTdRM3BBdfaDNERRHBf5vqGP8UyfrCKiFL1Yi+EFypL3zZigoWo2XVEBVNjFXrLllJpVqCENokEmvSJbqNkUwTuqmFUUSs0ccXc5NOx53NnT139t655/OBy9z7m3vOfe4+c2af+d3n/E51dwAAYMy+aN4BAADAvCmKAQAYPUUxAACjpygGAGD0FMUAAIyeohgAgNF7w7wDSJJrr722jxw5Mu8wAABYck8++eRnuvu67eMLURQfOXIkTzzxxLzDAABgyVXVv1xqXPsEAACjpygGAGD0FMUAAIzeXIviqlqrqtMbGxvzDAMAgJGba1Hc3We7++TKyso8wwAAYOQWYvWJeTly6uEvePz8e75nTpEAADBPeooBABg9RTEAAKOnKAYAYPQUxQAAjN6eFMVVdU1VPVlV37sX+wcAgFmaqiiuqvuq6mJVPb1t/HhVPVtVF6rq1JZv/XySh2YZKAAA7JVpZ4rvT3J860BVHUhyb5LbkxxLcqKqjlXVdyT5RJJPzzBOAADYM1OtU9zdj1bVkW3DtyW50N3PJUlVPZjkjiRvSnJNNgvl/6yqc939vzOLGAAAZmzIxTsOJXlhy+P1JN/Q3fckSVX9WJLP7FQQV9XJJCeT5PDhwwPCAACAYYYUxXWJsX7tTvf9l9u4u09X1UtJ1g4ePHjrgDgAAGCQIatPrCe5Ycvj65O8uJsddPfZ7j65srIyIAwAABhmSFH8eJKbq+rGqjqY5M4kZ3azg6paq6rTGxsbA8IAAIBhpl2S7YEkjyW5parWq+qu7n4lyT1JHklyPslD3f3Mbl7cTDEAAItg2tUnTuwwfi7JuSt98apaS7J29OjRK90FAAAMNtfLPJspBgBgEcy1KAYAgEUw16LYiXYAACwC7RMAAIyemWIAAEbPTDEAAKPnRDsAAEZPUQwAwOjpKQYAYPT0FAMAMHraJwAAGD1FMQAAo6enGACA0dNTDADA6GmfAABg9BTFAACMnqIYAIDRUxQDADB6Vp8AAGD03jDPF+/us0nOrq6u3j3POF515NTDr91//j3fM8dIAAC4mrRPAAAweopiAABGT1EMAMDoKYoBABg9RTEAAKM386K4qr6mqt5fVR+oqp+Y9f4BAGDWpiqKq+q+qrpYVU9vGz9eVc9W1YWqOpUk3X2+u9+V5IeTrM4+ZAAAmK1pZ4rvT3J860BVHUhyb5LbkxxLcqKqjk2+931J/jbJh2cWKQAA7JGpLt7R3Y9W1ZFtw7cludDdzyVJVT2Y5I4kn+juM0nOVNXDSf5oduFePS7kAQAwHkOuaHcoyQtbHq8n+Yaq+rYkP5jkjUnO7bRxVZ1McjJJDh8+PCAMAAAYZkhRXJcY6+7+SJKPvN7G3X26ql5Ksnbw4MFbB8QBAACDDFl9Yj3JDVseX5/kxd3soLvPdvfJlZWVAWEAAMAwQ4rix5PcXFU3VtXBJHcmObObHVTVWlWd3tjYGBAGAAAMM+2SbA8keSzJLVW1XlV3dfcrSe5J8kiS80ke6u5ndvPiZooBAFgE064+cWKH8XO5zMl0r6eq1pKsHT169Ep3AQAAg831Ms9migEAWARzLYr1FAMAsAiGLMk2WHefTXJ2dXX17nnG8XpcyAMAYLnNdaYYAAAWgfYJAABGz4l2AACMnvYJAABGT1EMAMDo6SkGAGD09BQDADB6c12neD+yZjEAwPLRUwwAwOjpKQYAYPT0FAMAMHraJwAAGD1FMQAAo6coBgBg9BTFAACMntUnAAAYvblevKO7zyY5u7q6evc847hSLuQBALActE8AADB6imIAAEZPUQwAwOgpigEAGD1FMQAAo7cnRXFVfX9V/XZV/UVVfddevAYAAMzK1EuyVdV9Sb43ycXu/tot48eT/HqSA0l+p7vf090fTPLBqvryJL+S5EOzDXvxWJ4NAGD/2s1M8f1Jjm8dqKoDSe5NcnuSY0lOVNWxLU/5xcn3AQBgYU1dFHf3o0k+u234tiQXuvu57v5ckgeT3FGb3pvkL7v772YXLgAAzN7QnuJDSV7Y8nh9MvbTSb4jyTuq6l2X2rCqTlbVE1X1xMsvvzwwDAAAuHJDL/Nclxjr7n5fkvddbsPuPl1VLyVZO3jw4K0D4wAAgCs2tCheT3LDlsfXJ3lx2o27+2ySs6urq3cPjAP2LSdpAsD8DS2KH09yc1XdmORTSe5M8iPTblxVa0nWjh49OjAMGCcFNQDMxtQ9xVX1QJLHktxSVetVdVd3v5LkniSPJDmf5KHufmbafXb32e4+ubKystu4YekdOfXwazcAYG9NPVPc3Sd2GD+X5NyVvLiZYsZkmuJ2yHOm2Xan2eSdtjX7DMBYDG2fGERPMYvuStoT9qKlYS9mi81AA8DnzbUoNlPMfja2ft6xvV8AxsVM8R5QPOw/0+RsGWZWd/seluE9A8A05loUwyK6kkJwSJ/vfjTtH347Pc8fjgAsGu0TwCDbC//dFrkKZAAWgfYJ4KpY1llzAJaD9glGS5G2N2b172qZOACuJu0TLKVpellZPHtRUCuiAZiG9gmWnkJ4ucxqBlnhDMBW2if2mP944eqYZgUQxyAAO/mieQcAAADzZqYYYApmnAGWmxPt2HcUJwDArDnRjn1Ngcws+DkCQPsEwC4pogGWj6L4KvIfKQDAYlIUA6MxzZrV/ngFGCdFMfuCC3AwD37uAMbD6hMslCGzdAoY5sHMMsBysPoEwIxc7g8zBTPAYnNFOwAARk9PMQtLOwQAcLUoigGugml6j/UnA8yPohjgKvMpCMDi0VMMAMDozXymuKpuSvLuJCvd/Y5Z75/lY9YMpqfFAmBvTDVTXFX3VdXFqnp62/jxqnq2qi5U1akk6e7nuvuuvQgWAAD2wrQzxfcn+Y0kv//qQFUdSHJvku9Msp7k8ao6092fmHWQy87MD7BX/H4BmM5URXF3P1pVR7YN35bkQnc/lyRV9WCSO5JMVRRX1ckkJ5Pk8OHDU4a7PMbeMjD29w+vx2oVAFfXkBPtDiV5Ycvj9SSHquotVfX+JF9fVb+w08bdfbq7V7t79brrrhsQBgAADDPkRLu6xFh3978meddUO6haS7J29OjRAWEAMGTW2IwzwLCZ4vUkN2x5fH2SF3ezg+4+290nV1ZWBoQBAADDDCmKH09yc1XdWFUHk9yZ5MxudlBVa1V1emNjY0AYAAAwzLRLsj2Q5LEkt1TVelXd1d2vJLknySNJzid5qLuf2c2LmykGAGARTLv6xIkdxs8lOXelL66nGOD1zWq1lr3oHdaPDCyLuV7m2UwxAACLYOaXed4NM8XLz3rEAMB+YKYYAIDRm2tRDAAAi0D7xILZqd3AZV6BWdLaBPCFtE8AADB62icAABg97RPMnI9lYb4WeV1jgEWlfQIAgNHTPgEAwOgpigEAGD1FMQAAo+dEO2bCyXWwHHY6lqc56e5Kfg/s9gQ+J/8Be8WJdgAAjJ72CQAARk9RDADA6CmKAQAYPUUxAACjZ/WJERh6tvZO21txAtgru/39stPzl22FikVbfWPR4oEhrD4BAMDoaZ8AAGD0FMUAAIyeohgAgNFTFAMAMHqKYgAARm/mS7JV1TVJfjPJ55J8pLv/cNavAQAAszTVTHFV3VdVF6vq6W3jx6vq2aq6UFWnJsM/mOQD3X13ku+bcbwAADBz07ZP3J/k+NaBqjqQ5N4ktyc5luREVR1Lcn2SFyZP+5/ZhAkAAHtnqvaJ7n60qo5sG74tyYXufi5JqurBJHckWc9mYfxULlN0V9XJJCeT5PDhw7uNe3SmubrTkCvMTXtVIlexA2ZpVr+3hjxnp995u9126NU/Z3VFuCFXmVuEK9Rt//eaJo5Fi3svYriSf5dFswh5upwhJ9odyudnhJPNYvhQkj9L8kNV9VtJzu60cXef7u7V7l697rrrBoQBAADDDDnRri4x1t39H0l+fKodVK0lWTt69OiAMAAAYJghM8XrSW7Y8vj6JC/uZgfdfba7T66srAwIAwAAhhlSFD+e5OaqurGqDia5M8mZ3eygqtaq6vTGxsaAMAAAYJhpl2R7IMljSW6pqvWququ7X0lyT5JHkpxP8lB3P7ObFzdTDADAIph29YkTO4yfS3LuSl9cTzEAAItgrpd5NlMMAMAiqO6edwypqpeT/MscXvraJJ+Zw+tydcjvcpPf5Sa/y01+l9ui5/eruvv/rQe8EEXxvFTVE929Ou842Bvyu9zkd7nJ73KT3+W2X/M71/YJAABYBIpiAABGb+xF8el5B8Cekt/lJr/LTX6Xm/wut32Z31H3FAMAQGKmGAAAxlsUV9Xxqnq2qi5U1al5x8P0qur5qvqHqnqqqp6YjL25qv6qqv5p8vXLtzz/FyZ5fraqvnvL+K2T/VyoqvdVVc3j/YxdVd1XVRer6uktYzPLZ1W9sar+eDL+0ao6cjXf39jtkN9fqqpPTY7hp6rq7Vu+J7/7RFXdUFV/U1Xnq+qZqvqZybjjdwlcJr/Le/x29+huSQ4k+WSSm5IcTPL3SY7NOy63qfP3fJJrt439cpJTk/unkrx3cv/YJL9vTHLjJO8HJt/7WJJvSlJJ/jLJ7fN+b2O8JfnWJG9L8vRe5DPJTyZ5/+T+nUn+eN7veUy3HfL7S0l+7hLPld99dEvy1iRvm9z/0iT/OMmh43cJbpfJ79Iev2OdKb4tyYXufq67P5fkwSR3zDkmhrkjye9N7v9eku/fMv5gd/9Xd/9zkgtJbquqtyb5su5+rDePxt/fsg1XUXc/muSz24Znmc+t+/pAkm/3qcDVs0N+dyK/+0h3v9Tdfze5/+9Jzic5FMfvUrhMfney7/M71qL4UJIXtjxez+UTzWLpJB+qqier6uRk7Cu7+6Vk80BO8hWT8Z1yfWhyf/s4i2GW+Xxtm+5+JclGkrfsWeRM656q+vikveLVj9fld5+afOz99Uk+Gsfv0tmW32RJj9+xFsWX+ivEMhz7xzd399uS3J7kp6rqWy/z3J1y7Wdgf7qSfMr14vmtJF+d5OuSvJTkVyfj8rsPVdWbkvxpkp/t7n+73FMvMSa/C+4S+V3a43esRfF6khu2PL4+yYtzioVd6u4XJ18vJvnzbLbDfHryEU0mXy9Onr5Trtcn97ePsxhmmc/XtqmqNyRZyfQf57MHuvvT3f0/3f2/SX47m8dwIr/7TlV9cTYLpj/s7j+bDDt+l8Sl8rvMx+9Yi+LHk9xcVTdW1cFsNnefmXNMTKGqrqmqL331fpLvSvJ0NvP3zsnT3pnkLyb3zyS5c3KG641Jbk7ysclHev9eVd846V/60S3bMH+zzOfWfb0jyV9P+tqYk1cLpokfyOYxnMjvvjLJxe8mOd/dv7blW47fJbBTfpf6+J3nWX7zvCV5ezbPpPxkknfPOx63qfN2UzbPbv37JM+8mrts9iB9OMk/Tb6+ecs2757k+dlsWWEiyWo2D+ZPJvmNTC5m43bVc/pANj+C++9szhrcNct8JvmSJH+SzZM+Ppbkpnm/5zHddsjvHyT5hyQfz+Z/im+V3/13S/It2fyo++NJnprc3u74XY7bZfK7tMevK9oBADB6Y22fAACA1yiKAQAYPUUxAACjpygGAGD0FMUAAIyeohgAgNFTFAMAMHqKYgAARu//AONLXGkv9MOEAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQdklEQVR4nO3dX4xc91UH8O/BxUVKYVWIQZUTYxdHERYPtF2lIFCFBBSnsKRAhWIe+KMoVoEgeEDCFTzw2CJAoiJQuRAFECSEUlpbNQqoUEVIEU2C0japFeqGVtkmqlMqmQohSuDwsJOwXbzOrO+sZ3bu5yNdeea3c++c9fFdn/3Nub9b3R0AABizr5p3AAAAMG+KYgAARk9RDADA6CmKAQAYPUUxAACjpygGAGD0XjHvAJLk+uuv78OHD887DAAAltxjjz32he4+sHV8IYriw4cP59FHH513GAAALLmq+uzlxrVPAAAweopiAABGT1EMAMDozbUorqq1qjp96dKleYYBAMDIzbUo7u6z3X1yZWVlnmEAADByC7H6xLwcPvWhr3j+mXf+4JwiAQBgnvQUAwAweopiAABGT1EMAMDoKYoBABi9XSmKq+q6qnqsqn5oN44PAACzNFVRXFX3VNXFqnpiy/jxqnqqqi5U1alNX/qVJA/MMlAAANgt084U35vk+OaBqtqX5O4ktyY5luREVR2rqu9L8skkn59hnAAAsGumWqe4ux+qqsNbhm9JcqG7n06Sqro/yW1JXpXkumwUyv9RVee6+39mFjEAAMzYkJt3HEzyzKbn60ne2N13JUlV/XSSL2xXEFfVySQnk+TQoUMDwgAAgGGGFMV1mbF+6UH3vVfaubtPV9VzSdb279//hgFxAADAIENWn1hPcuOm5zckeXYnB+jus919cmVlZUAYAAAwzJCi+JEkN1XVkaran+T2JGd2coCqWquq05cuXRoQBgAADDPtkmz3JXk4yc1VtV5Vd3T3C0nuSvJgkvNJHujuJ3fy5maKAQBYBNOuPnFim/FzSc5d7ZtX1VqStaNHj17tIQAAYLC53ubZTDEAAItgrkWxnmIAABaBmWIAAEZvrkUxAAAsAu0TAACMnvYJAABGT/sEAACjp30CAIDR0z4BAMDoaZ8AAGD0FMUAAIyeohgAgNFzoR0AAKPnQjsAAEZP+wQAAKOnKAYAYPQUxQAAjJ6iGACA0bP6BAAAo/eKeb55d59NcnZ1dfXOecbxosOnPvTS48+88wfnGAkAANeS9gkAAEZPUQwAwOgpigEAGD1FMQAAo6coBgBg9GZeFFfVt1bVe6rqfVX1s7M+PgAAzNpURXFV3VNVF6vqiS3jx6vqqaq6UFWnkqS7z3f325P8eJLV2YcMAACzNe1M8b1Jjm8eqKp9Se5OcmuSY0lOVNWxydd+OMk/JPnwzCIFAIBdMtXNO7r7oao6vGX4liQXuvvpJKmq+5PcluST3X0myZmq+lCSP5tduNeOG3kAAIzHkDvaHUzyzKbn60neWFXfk+RHk7wyybntdq6qk0lOJsmhQ4cGhAEAAMMMKYrrMmPd3R9J8pGX27m7T1fVc0nW9u/f/4YBcQAAwCBDVp9YT3Ljpuc3JHl2Jwfo7rPdfXJlZWVAGAAAMMyQoviRJDdV1ZGq2p/k9iRndnKAqlqrqtOXLl0aEAYAAAwz7ZJs9yV5OMnNVbVeVXd09wtJ7kryYJLzSR7o7id38uZmigEAWATTrj5xYpvxc7nCxXQvp6rWkqwdPXr0ag8BAACDzfU2z2aKAQBYBHMtivUUAwCwCIYsyTZYd59NcnZ1dfXOecbxctzIAwBguc11phgAABaB9gkAAEbPhXYAAIye9gkAAEZP+wQAAKOnfQIAgNHTPgEAwOjNdZ3ivciaxQAAy8dMMQAAo+dCOwAARs+FdgAAjJ72CQAARk9RDADA6CmKAQAYPUUxAACjZ/UJAABGz+oTAACMnjvaDeDudgAAy0FPMQAAo6coBgBg9BTFAACMnqIYAIDR25WiuKreWlXvraoPVtWbd+M9AABgVqZefaKq7knyQ0kudve3bRo/nuR3kuxL8gfd/c7u/kCSD1TVq5P8ZpK/mW3Yi8dKFAAAe9dOZorvTXJ880BV7Utyd5JbkxxLcqKqjm16ya9Nvg4AAAtr6qK4ux9K8sUtw7ckudDdT3f3l5Pcn+S22vCuJH/d3f90ueNV1cmqerSqHn3++eevNn4AABhsaE/xwSTPbHq+Phn7hSTfl+RtVfX2y+3Y3ae7e7W7Vw8cODAwDAAAuHpD72hXlxnr7n53kne/7M5Va0nWjh49OjAMAAC4ekOL4vUkN256fkOSZ6fdubvPJjm7urp658A4YM9ykSYAzN/QoviRJDdV1ZEkn0tye5KfmHZnM8UwjIIaAGZj6p7iqrovycNJbq6q9aq6o7tfSHJXkgeTnE/yQHc/Oe0xu/tsd59cWVnZadyw9A6f+tBLGwCwu6aeKe7uE9uMn0ty7mre3EwxYzJNcbvbr5lmNtnsMwBjNLR9YhA9xTCdWRXLQ14PAMtsrkWxmWIW3dXMmi7rTOuyfl8AkJgp3hWKh71nmpxtnVndi7k1mwwAlzfXohgW0bSF4NUU0sti2l/8/IIIwF6hfQJmYFmL392iWAZg0WifAAaZtq1ku18cFMgALALtE8BMzWrWfMiycgCwU9onWErbzT5qc1hsu1FQK6IBmIb2CZaeQni5mEEGYDdon9hlZqzg2hiy3JxzEwBFMbDUFL8ATENRDDAFxTXAcnOhHXuO4gQAmDUX2rGnKZCZBf+OANA+AbBDimiA5aMovob8RwoAsJgUxcBoTLNsm3WtAcZJUcyeoFABAHaT1SdYKENaTBTOzIO2KIDlYPUJgBm50i9mCmaAxfZV8w4AAADmTU8xC0s7BABwrSiKAa6BaXqP9ScDzI+iGOAa8ykIwOJRFDN3CgSYntlkgN0x8wvtquq1VfWHVfW+WR8bAAB2w1RFcVXdU1UXq+qJLePHq+qpqrpQVaeSpLuf7u47diNYAADYDdO2T9yb5HeT/PGLA1W1L8ndSb4/yXqSR6rqTHd/ctZBAnB1tFsATGeqori7H6qqw1uGb0lyobufTpKquj/JbUmmKoqr6mSSk0ly6NChKcNdHtv10Y7lPy19xHBlVqsAuLaG9BQfTPLMpufrSQ5W1TdU1XuSvK6q3rHdzt19urtXu3v1wIEDA8IAAIBhhqw+UZcZ6+7+1yRvn+oAVWtJ1o4ePTogDACGzBqbcQYYNlO8nuTGTc9vSPLsTg7Q3We7++TKysqAMAAAYJghRfEjSW6qqiNVtT/J7UnO7OQAVbVWVacvXbo0IAwAABhm2iXZ7kvycJKbq2q9qu7o7heS3JXkwSTnkzzQ3U/u5M3NFAMAsAimXX3ixDbj55Kcu9o311MM8PJmtVrLbvQO60cGlsXM72i3E2aKAQBYBENWnxjMTPHysx4xALAXmCkGAGD05loUAwDAItA+sWB2evtnF7kAV0NrE8BX0j4BAMDoaZ8AAGD0tE8wcz6Whfla5HWNARaV9gkAAEZP+wQAAKOnKAYAYPQUxQAAjJ4L7ZgJF9fBctjuXJ7morur+Tmw0wv4XPwH7BYX2gEAMHraJwAAGD1FMQAAo6coBgBg9BTFAACMntUnRmDo1drb7W/FCWC37PTny3avX7YVKhZt9Y1FiweGsPoEAACjp30CAIDRUxQDADB6imIAAEZPUQwAwOgpigEAGL2ZL8lWVdcl+b0kX07yke7+01m/BwAAzNJUM8VVdU9VXayqJ7aMH6+qp6rqQlWdmgz/aJL3dfedSX54xvECAMDMTds+cW+S45sHqmpfkruT3JrkWJITVXUsyQ1Jnpm87L9nEyYAAOyeqdonuvuhqjq8ZfiWJBe6++kkqar7k9yWZD0bhfHjuULRXVUnk5xMkkOHDu007tGZ5u5OQ+4wN+1didzFDpilWf3cGvKa7X7m7XTfoXf/nNUd4YbcZW4R7lC39e9rmjgWLe7diOFq/l4WzSLk6UqGXGh3MP83I5xsFMMHk7w/yY9V1e8nObvdzt19urtXu3v1wIEDA8IAAIBhhlxoV5cZ6+7+9yQ/M9UBqtaSrB09enRAGAAAMMyQmeL1JDduen5Dkmd3coDuPtvdJ1dWVgaEAQAAwwwpih9JclNVHamq/UluT3JmJweoqrWqOn3p0qUBYQAAwDDTLsl2X5KHk9xcVetVdUd3v5DkriQPJjmf5IHufnInb26mGACARTDt6hMnthk/l+Tc1b65nmIAABbBXG/zbKYYAIBFUN097xhSVc8n+ewc3vr6JF+Yw/tybcjvcpPf5Sa/y01+l9ui5/ebu/v/rQe8EEXxvFTVo929Ou842B3yu9zkd7nJ73KT3+W2V/M71/YJAABYBIpiAABGb+xF8el5B8Cukt/lJr/LTX6Xm/wutz2Z31H3FAMAQGKmGAAAxlsUV9Xxqnqqqi5U1al5x8P0quozVfWJqnq8qh6djH19Vf1tVX1q8uerN73+HZM8P1VVP7Bp/A2T41yoqndXVc3j+xm7qrqnqi5W1RObxmaWz6p6ZVX9+WT8H6vq8LX8/sZum/z+elV9bnIOP15Vb9n0NfndI6rqxqr6+6o6X1VPVtUvTsadv0vgCvld3vO3u0e3JdmX5NNJXptkf5KPJTk277hsU+fvM0mu3zL2G0lOTR6fSvKuyeNjk/y+MsmRSd73Tb720STfmaSS/HWSW+f9vY1xS/KmJK9P8sRu5DPJzyV5z+Tx7Un+fN7f85i2bfL760l++TKvld89tCV5TZLXTx5/bZJ/nuTQ+bsE2xXyu7Tn71hnim9JcqG7n+7uLye5P8ltc46JYW5L8keTx3+U5K2bxu/v7v/s7n9JciHJLVX1miRf190P98bZ+Meb9uEa6u6Hknxxy/As87n5WO9L8r0+Fbh2tsnvduR3D+nu57r7nyaPv5TkfJKDcf4uhSvkdzt7Pr9jLYoPJnlm0/P1XDnRLJZO8jdV9VhVnZyMfVN3P5dsnMhJvnEyvl2uD04ebx1nMcwyny/t090vJLmU5Bt2LXKmdVdVfXzSXvHix+vyu0dNPvZ+XZJ/jPN36WzJb7Kk5+9Yi+LL/RZiGY6947u6+/VJbk3y81X1piu8drtc+zewN11NPuV68fx+km9J8u1JnkvyW5Nx+d2DqupVSf4yyS91979d6aWXGZPfBXeZ/C7t+TvWong9yY2bnt+Q5Nk5xcIOdfezkz8vJvmrbLTDfH7yEU0mf16cvHy7XK9PHm8dZzHMMp8v7VNVr0iykuk/zmcXdPfnu/u/u/t/krw3G+dwIr97TlV9dTYKpj/t7vdPhp2/S+Jy+V3m83esRfEjSW6qqiNVtT8bzd1n5hwTU6iq66rqa198nOTNSZ7IRv5+avKyn0rywcnjM0lun1zheiTJTUk+OvlI70tV9R2T/qWf3LQP8zfLfG4+1tuS/N2kr405ebFgmviRbJzDifzuKZNc/GGS893925u+5PxdAtvld6nP33le5TfPLclbsnEl5aeT/Oq847FNnbfXZuPq1o8lefLF3GWjB+nDST41+fPrN+3zq5M8P5VNK0wkWc3GyfzpJL+byc1sbNc8p/dl4yO4/8rGrMEds8xnkq9J8hfZuOjjo0leO+/veUzbNvn9kySfSPLxbPyn+Br53Xtbku/OxkfdH0/y+GR7i/N3ObYr5Hdpz193tAMAYPTG2j4BAAAvURQDADB6imIAAEZPUQwAwOgpigEAGD1FMQAAo6coBgBg9BTFAACM3v8CZHJfT3L7WMoAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -584,12 +675,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQXElEQVR4nO3db4hl91kH8O/j1lSoOlizStlk3dQNxcUXtg7xL6Vg1U11jVbRbAVbCV2qRvSF4BYFfVkFBYuxZbUhKpIY659m7UoUtQQhtElK/yQNsdvYkmlK01pYi4g1+vhibtLrOLO9d8+dvXfu+XzgMPf+5p5znplnzt1nf/c551R3BwAAxuzLlh0AAAAsm6IYAIDRUxQDADB6imIAAEZPUQwAwOgpigEAGL0XLDuAJLn22mv72LFjyw4DAIA198gjj3y2uw/vHF+JovjYsWN5+OGHlx0GAABrrqo+sdu49gkAAEZPUQwAwOgttSiuqlNVde7SpUvLDAMAgJFbalHc3ee7+8zGxsYywwAAYOS0TwAAMHorcfWJZTl29t3/5/nH3/IDS4oEAIBlMlMMAMDoKYoBABg9RTEAAKO3L0VxVb2oqh6pqh/cj+0DAMAizVQUV9WdVfVMVT26Y/xkVT1RVRer6uzUt345yb2LDBQAAPbLrDPFdyU5OT1QVYeS3JHk5iQnkpyuqhNV9eokH0ny6QXGCQAA+2amS7J19wNVdWzH8E1JLnb3k0lSVfckuSXJVyZ5UbYL5f+oqgvd/T8LixgAABZsyHWKjyR5aur5VpJv6+7bk6Sq3pDks3sVxFV1JsmZJDl69OiAMAAAYJghJ9rVLmP9/IPuu7r7r/daubvPdfdmd28ePnx4QBgAADDMkKJ4K8n1U8+vS/L0PBuoqlNVde7SpUsDwgAAgGGGFMUPJbmxqm6oqmuS3JrkvsWEBQAAV8+sl2S7O8mDSV5WVVtVdVt3P5vk9iT3J3k8yb3d/dg8O+/u8919ZmNjY964AQBgYWa9+sTpPcYvJLlwpTuvqlNJTh0/fvxKNwEAAIMt9TbPZooBAFgFSy2KAQBgFSy1KHb1CQAAVoH2CQAARk/7BAAAo6d9AgCA0dM+AQDA6GmfAABg9LRPAAAwetonAAAYPe0TAACMnqIYAIDR01MMAMDo6SkGAGD0tE8AADB6imIAAEZPUQwAwOgpigEAGD1FMQAAo+eSbAAAjJ5LsgEAMHraJwAAGD1FMQAAo6coBgBg9BTFAACM3sKL4qr6pqp6e1W9s6p+ZtHbBwCARZupKK6qO6vqmap6dMf4yap6oqouVtXZJOnux7v7TUl+PMnm4kMGAIDFmnWm+K4kJ6cHqupQkjuS3JzkRJLTVXVi8r0fSvJPSf5+YZECAMA+mako7u4Hknxux/BNSS5295Pd/YUk9yS5ZfL6+7r7O5P85CKDBQCA/fCCAeseSfLU1POtJN9WVa9K8tokL0xyYa+Vq+pMkjNJcvTo0QFhAADAMEOK4tplrLv7PUne86VW7u5zSc4lyebmZg+IAwAABhlSFG8luX7q+XVJnp5nA1V1Ksmp48ePDwhjcY6dfffzjz/+lh9YYiQAAFxNQy7J9lCSG6vqhqq6JsmtSe5bTFgAAHD1zHpJtruTPJjkZVW1VVW3dfezSW5Pcn+Sx5Pc292PzbPz7j7f3Wc2NjbmjRsAABZmpvaJ7j69x/iFXOZkOgAAOAiWepvnqjpVVecuXbq0zDAAABi5pRbF2icAAFgFZooBABg9M8UAAIzekOsUrzXXLAYAGA/tEwAAjJ72CQAARm+pRTEAAKwC7RMAAIye9gkAAEZP+wQAAKOnKAYAYPT0FAMAMHpLvXlHd59Pcn5zc/ONy4zjS3EjDwCA9aZ9AgCA0VMUAwAweopiAABGT1EMAMDoKYoBABg9l2QDAGD03OYZAIDR0z4BAMDoKYoBABi9pd7R7iBydzsAgPVjphgAgNFTFAMAMHr7UhRX1Q9X1e9X1buq6vv2Yx8AALAoMxfFVXVnVT1TVY/uGD9ZVU9U1cWqOpsk3f1X3f3GJG9I8hMLjRgAABZsnhPt7kryu0n+6LmBqjqU5I4k35tkK8lDVXVfd39k8pJfnXx/LTnpDgBgPcw8U9zdDyT53I7hm5Jc7O4nu/sLSe5Jcktt+40kf9Pd799te1V1pqoerqqHP/OZz1xp/AAAMNjQnuIjSZ6aer41Gfv5JK9O8mNV9abdVuzuc9292d2bhw8fHhgGAABcuaHXKa5dxrq735rkrV9y5apTSU4dP358YBgAAHDlhs4UbyW5fur5dUmennXl7j7f3Wc2NjYGhgEAAFdu6EzxQ0lurKobknwyya1JXjfrymaKOcj240TL6W1O22v7Q2JwoigAfNHMRXFV3Z3kVUmuraqtJL/W3e+oqtuT3J/kUJI7u/uxWbfZ3eeTnN/c3HzjfGHD1bdXwTp0/VkK0lkK2HlfAwB80cxFcXef3mP8QpILV7JzM8WsuqtRRM67j1lev9+z2GaWAVg3Q9snBjFTzLpY1xnYdf25AGCnpRbFZophNZgFBmDszBTDmtuP2d5Zi2jFNgAHxVKLYlgV2gS+aGiP835cKQMA9pv2CUZFYbb/hhTV0zkZcrUOAJiX9okFUWwdPGaHl8fvHoBVo30CWAv+YwrAEENv8zxIVZ2qqnOXLl1aZhgAAIyc9gnWko/nAYB5aJ8ARkm7BQDTFMXAyjDDD8CyKIo5cMzw8ZyrWUT7uwNYb060AwBg9JxoBzDFjDDAOGmf4EBTwIzPou6Yt2r7AmC5FMWsLAUGi+ZEPgD2oihmbSh4eI6/BQDmpSjeB2Y4r5xihmXwdweAq08AADB6rj7BgWAmj4Pmcn+zPkECWD3aJ1g6BS9jpt0KYDUoiveZf/CAK+G9A+DqWmpPMQAArAIzxQBzMosLsH4UxQADXElPvD56gNWz8PaJqnppVb2jqt656G0DAMB+mGmmuKruTPKDSZ7p7m+eGj+Z5HeSHEryB939lu5+MsltimKA+ZhBBlieWWeK70pycnqgqg4luSPJzUlOJDldVScWGh0AAFwFM80Ud/cDVXVsx/BNSS5OZoZTVfckuSXJR2bZZlWdSXImSY4ePTpjuAebk3OAK+G9A2D/DekpPpLkqannW0mOVNXXVtXbk7y8qt6818rdfa67N7t78/DhwwPCAACAYYZcfaJ2Gevu/tckb5ppA1Wnkpw6fvz4gDA4iPROwnBmkAEWZ8hM8VaS66eeX5fk6Xk20N3nu/vMxsbGgDAAAGCYITPFDyW5sapuSPLJJLcmed08GzBTDLAcZpkB/q+ZZoqr6u4kDyZ5WVVtVdVt3f1sktuT3J/k8ST3dvdj8+zcTDEAAKtg1qtPnN5j/EKSC1e6czPFAACsgoXf0W4eZooBAFgFQ3qKBxvzTPFeV1/Q2wcs0n70DutHBtaRmWIAAEZvqUUxAACsAu0TAAfIkBvfzLvuMtsktGgAV5v2CQAARk/7BAAAo6d9AmDNXM0Wi1m2c7n2B20SwKrQPgEAwOhpnwAAYPQUxQAAjJ6iGACA0XOiHVdsrxNkZhkHFmsVTq4DOMicaAcAwOhpnwAAYPQUxQAAjJ6iGACA0VMUAwAweq4+scIO0u1Pnb0O43Q13qf2en/Za3/zvn5R687iIL2vw9i4+gQAAKOnfQIAgNFTFAMAMHqKYgAARk9RDADA6CmKAQAYvYVfkq2qXpTk95J8Icl7uvtPFr0PAABYpJlmiqvqzqp6pqoe3TF+sqqeqKqLVXV2MvzaJO/s7jcm+aEFxwsAAAs3a/vEXUlOTg9U1aEkdyS5OcmJJKer6kSS65I8NXnZfy8mTAAA2D8ztU909wNVdWzH8E1JLnb3k0lSVfckuSXJVrYL4w/kMkV3VZ1JciZJjh49Om/c7GKvOyUNvRvULNuaJSZgvc1yvC/yPWHI+9GQ97V57dfPPO8d+ua9g95+391vkVbhToGz/H0t83e3CnGsQgyXM+REuyP54oxwsl0MH0nyF0l+tKreluT8Xit397nu3uzuzcOHDw8IAwAAhhlyol3tMtbd/e9JfnqmDVSdSnLq+PHjA8IAAIBhhswUbyW5fur5dUmenmcD3X2+u89sbGwMCAMAAIYZUhQ/lOTGqrqhqq5JcmuS++bZQFWdqqpzly5dGhAGAAAMM+sl2e5O8mCSl1XVVlXd1t3PJrk9yf1JHk9yb3c/Ns/OzRQDALAKZr36xOk9xi8kuXClO9dTDADAKljqbZ7NFAMAsAqqu5cdQ6rqM0k+sYRdX5vks0vYL/tDPteLfK4X+Vwv8rlexpbPb+ju/3c94JUoipelqh7u7s1lx8FiyOd6kc/1Ip/rRT7Xi3xuW2r7BAAArAJFMQAAozf2ovjcsgNgoeRzvcjnepHP9SKf60U+M/KeYgAASMwUAwDAeIviqjpZVU9U1cWqOrvseNhdVX28qj5cVR+oqocnYy+uqr+rqo9Ovn7N1OvfPMnpE1X1/VPj3zrZzsWqemtV1TJ+nrGpqjur6pmqenRqbGH5q6oXVtWfTsbfW1XHrubPNzZ75PPXq+qTk2P0A1X1mqnvyecKq6rrq+ofq+rxqnqsqn5hMu4YPWAuk0vH5zy6e3RLkkNJPpbkpUmuSfLBJCeWHZdl11x9PMm1O8Z+M8nZyeOzSX5j8vjEJJcvTHLDJMeHJt97X5LvSFJJ/ibJzcv+2cawJHllklckeXQ/8pfkZ5O8ffL41iR/uuyfeZ2XPfL560l+aZfXyueKL0lekuQVk8dfleSfJ3lzjB6w5TK5dHzOsYx1pvimJBe7+8nu/kKSe5LcsuSYmN0tSf5w8vgPk/zw1Pg93f2f3f0vSS4muamqXpLkq7v7wd4+mv9oah32UXc/kORzO4YXmb/pbb0zyff4FGD/7JHPvcjniuvuT3X3+yePP5/k8SRH4hg9cC6Ty73I5S7GWhQfSfLU1POtXP6Ph+XpJH9bVY9U1ZnJ2Nd396eS7TeCJF83Gd8rr0cmj3eOsxyLzN/z63T3s0kuJfnafYucvdxeVR+atFc891G7fB4gk4/CX57kvXGMHmg7cpk4Pmc21qJ4t//ZuAzHavqu7n5FkpuT/FxVvfIyr90rr/J9MFxJ/uR2+d6W5BuTfEuSTyX5rcm4fB4QVfWVSf48yS92979d7qW7jMnpCtkll47POYy1KN5Kcv3U8+uSPL2kWLiM7n568vWZJH+Z7daXT08+4snk6zOTl++V163J453jLMci8/f8OlX1giQbmf3jfRaguz/d3f/d3f+T5PezfYwm8nkgVNWXZ7uI+pPu/ovJsGP0ANotl47P+Yy1KH4oyY1VdUNVXZPthvH7lhwTO1TVi6rqq557nOT7kjya7Vy9fvKy1yd51+TxfUlunZwhe0OSG5O8b/Lx3+er6tsn/U8/NbUOV98i8ze9rR9L8g+TPjiukueKp4kfyfYxmsjnypv8/t+R5PHu/u2pbzlGD5i9cun4nNOyz/Rb1pLkNdk+O/NjSX5l2fFYds3RS7N9duwHkzz2XJ6y3cP090k+Ovn64ql1fmWS0ycydYWJJJvZfjP4WJLfzeTGNZZ9z+Hd2f7I7r+yPctw2yLzl+QrkvxZtk8SeV+Sly77Z17nZY98/nGSDyf5ULb/0XyJfB6MJcl3Z/vj7w8l+cBkeY1j9OAtl8ml43OOxR3tAAAYvbG2TwAAwPMUxQAAjJ6iGACA0VMUAwAweopiAABGT1EMAMDoKYoBABg9RTEAAKP3vzX1Xy2wYGipAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQXUlEQVR4nO3db4hl91kH8O9j6laoOmgTpWyybuqG4r6y7ZL6j1JQdFOdxn9oVsEqoUPViL4QXKmgL62gL4rRsqUhKpIYa9UsXYlSLUEINom0NWmI3caWjCmNtTCKiDX6+GJu4nWc2d67587ee+d8PnCYe39zz7nPzHPPnWd+9znnVHcHAADG7EuWHQAAACybohgAgNFTFAMAMHqKYgAARk9RDADA6CmKAQAYvZctO4Akuf766/vkyZPLDgMAgCPu8ccf/1x337B3fCWK4pMnT+axxx5bdhgAABxxVfXp/ca1TwAAMHqKYgAARm+pRXFVbVbVhZ2dnWWGAQDAyC21KO7ui929tbGxscwwAAAYOe0TAACM3kqcfWJZTp7/wP+5/6lf/e4lRQIAwDKZKQYAYPQUxQAAjJ6iGACA0TuUoriqXlFVj1fV9xzG9gEAYJFmKoqr6p6qer6qntgzfraqnq6qy1V1fupbv5DkgUUGCgAAh2XWmeJ7k5ydHqiq65LcneS2JKeTnKuq01X1HUk+nuSzC4wTAAAOzUynZOvuh6vq5J7hW5Nc7u5nkqSq7k9ye5IvT/KK7BbK/15Vl7r7vxcWMQAALNiQ8xQfT/Ls1P3tJG/o7ruSpKp+PMnnDiqIq2oryVaSnDhxYkAYAAAwzJCiuPYZ65dudN97pZW7+0JVfSbJ5rFjx14/IA4AABhkyNkntpPcNHX/xiTPzbOB7r7Y3VsbGxsDwgAAgGGGFMWPJrmlqm6uqmNJ7kjy4DwbqKrNqrqws7MzIAwAABhm1lOy3ZfkkSSvqartqrqzu19IcleSh5I8leSB7n5ynic3UwwAwCqY9ewT5w4Yv5Tk0tU+eVVtJtk8derU1W4CAAAGW+plns0UAwCwCpZaFAMAwCpYalHsQDsAAFaB9gkAAEbPTDEAAKNnphgAgNFzoB0AAKOnKAYAYPT0FAMAMHp6igEAGD3tEwAAjJ6iGACA0dNTDADA6OkpBgBg9LRPAAAweopiAABGT1EMAMDoKYoBABg9Z58AAGD0nH0CAIDR0z4BAMDoKYoBABg9RTEAAKOnKAYAYPQUxQAAjN7Ci+Kq+oaqendVva+qfnLR2wcAgEWbqSiuqnuq6vmqemLP+NmqerqqLlfV+STp7qe6++1JfijJmcWHDAAAizXrTPG9Sc5OD1TVdUnuTnJbktNJzlXV6cn33pLkr5N8cGGRAgDAIZmpKO7uh5N8fs/wrUkud/cz3f2FJPcnuX3y+Ae7+1uS/OgigwUAgMPwsgHrHk/y7NT97SRvqKo3Jfn+JC9PcumglatqK8lWkpw4cWJAGAAAMMyQorj2Gevu/lCSD32xlbv7QpILSXLmzJkeEAcAAAwypCjeTnLT1P0bkzw3zwaqajPJ5qlTpwaEsTgnz3/gpduf+tXvXmIkAABcS0NOyfZokluq6uaqOpbkjiQPLiYsAAC4dmY9Jdt9SR5J8pqq2q6qO7v7hSR3JXkoyVNJHujuJ+d58u6+2N1bGxsb88YNAAALM1P7RHefO2D8Uq5wMN0Xs2rtEwAAjNNSL/NsphgAgFWw1KIYAABWwVKL4qrarKoLOzs7ywwDAICR0z4BAMDoDTlP8ZHmnMUAAOOhfQIAgNHTPgEAwOg5+wQAAKOnfQIAgNHTPgEAwOhpnwAAYPQUxQAAjJ6eYgAARk9PMQAAo+eKdjNwdTsAgKNNTzEAAKOnKAYAYPQUxQAAjJ6zTwAAMHrOPgEAwOhpnwAAYPQUxQAAjJ6iGACA0VMUAwAweq5oNydXtwMAOHoOZaa4qr63qt5TVX9aVd95GM8BAACLMnNRXFX3VNXzVfXEnvGzVfV0VV2uqvNJ0t1/0t1vS/LjSX54oREDAMCCzTNTfG+Ss9MDVXVdkruT3JbkdJJzVXV66iG/NPk+AACsrJmL4u5+OMnn9wzfmuRydz/T3V9Icn+S22vXO5P8WXf/7eLCBQCAxRt6oN3xJM9O3d9O8oYkP5PkO5JsVNWp7n733hWraivJVpKcOHFiYBjL4aA7AICjYWhRXPuMdXe/K8m7rrRid19IciFJzpw50wPjAACAqzb07BPbSW6aun9jkudmXbmqNqvqws7OzsAwAADg6g0tih9NcktV3VxVx5LckeTB4WEBAMC1M3P7RFXdl+RNSa6vqu0kv9zd762qu5I8lOS6JPd095OzbrO7Lya5eObMmbfNFzYcTdN96tMOo2ddTzwA/K+Zi+LuPnfA+KUklxYWEayJeYvKIQXvQc+1qBgAYOyWepnnqtpMsnnq1KllhgEzOayCct7tHvT4w55lNrMMwFG21KJY+wSrbmghvO4zs+sePwDMykwxLMC6F49mgQEYOzPFcMQtqj3joMdcqYhWbAOwLpZaFMOqULxdvb1F9EG/P79jAFaZ9glGZZbCbN1bIdbNvDlRUANwGLRPLIg/2utH8Xs45m2/GPIYAFgU7RPAkeAfUwCGGHqZ50GqarOqLuzs7CwzDAAARk77BEeSj94BgHlonwBGSbsFANMUxcDKWOUZfkU0wNHmlGysHcUJL1rlIhqA9bLUA+26+2J3b21sbCwzDAAARk77BMAUn0QAjJOimLWmgBmfeVsmhrxGtGcAjIeimJWl4GXdeM0CrC9FMUeGWT1edNBrwWsEgIMoig+B2aKrp2hhGbzuAHBKNtaCooV1559lgNXmMs8Ah8A/cgDrRfsES6d4YMzMIAOsBkUxwApSLANcW4riQ+YPGwDA6lMUA8zJP7sAR4+iGGCAq+mJ10cPsHoWXhRX1auTvCPJRnf/4KK3D3BUKZYBludLZnlQVd1TVc9X1RN7xs9W1dNVdbmqzidJdz/T3XceRrAAAHAYZiqKk9yb5Oz0QFVdl+TuJLclOZ3kXFWdXmh0AABwDczUPtHdD1fVyT3Dtya53N3PJElV3Z/k9iQfn2WbVbWVZCtJTpw4MWO4683BOcDV8N4BcPhmnSnez/Ekz07d305yvKpeWVXvTvLaqvrFg1bu7gvdfaa7z9xwww0DwgAAgGGGHGhX+4x1d/9zkrfPtIGqzSSbp06dGhAG68gBRTCcGWSAxRkyU7yd5Kap+zcmeW6eDXT3xe7e2tjYGBAGAAAMM2Sm+NEkt1TVzUn+MckdSX5kng2YKQZYDrPMAP/XrKdkuy/JI0leU1XbVXVnd7+Q5K4kDyV5KskD3f3kPE9uphgAgFUw69knzh0wfinJpat9cjPFAACsgiE9xYOZKQYAYBUs/DLP8xjzTLF+PuBaOIz3Gu9fwFFkphgAgNFbalEMAACrQPvECvBRJDCrIRe+mXfdZb43eV8ErjXtEwAAjJ72CQAARk/7BMARcy1bLGbZzpXaH7RJAKtC+wQAAKOnfQIAgNFTFAMAMHqKYgAARs+Bdly1gw6QmWUcWKxVOLgOYJ050A4AgNHTPgEAwOgpigEAGD1FMQAAo6coBgBg9Jx9YoWt0+VPHb0O43Qt3qcOen856Pnmffyi1p3FOr2vw9g4+wQAAKOnfQIAgNFTFAMAMHqKYgAARk9RDADA6CmKAQAYvYWfkq2qXpHkt5J8IcmHuvv3F/0cAACwSDPNFFfVPVX1fFU9sWf8bFU9XVWXq+r8ZPj7k7yvu9+W5C0LjhcAABZu1vaJe5OcnR6oquuS3J3ktiSnk5yrqtNJbkzy7ORh/7WYMAEA4PDM1D7R3Q9X1ck9w7cmudzdzyRJVd2f5PYk29ktjD+SKxTdVbWVZCtJTpw4MW/c7OOgKyUNvRrULNuaJSbgaJtlf1/ke8KQ96Mh72vzOqyfed4r9M17Bb3DvrrfIq3ClQJneX0t83e3CnGsQgxXMuRAu+P53xnhZLcYPp7k/Ul+oKp+O8nFg1bu7gvdfaa7z9xwww0DwgAAgGGGHGhX+4x1d/9bkp+YaQNVm0k2T506NSAMAAAYZshM8XaSm6bu35jkuXk20N0Xu3trY2NjQBgAADDMkKL40SS3VNXNVXUsyR1JHpxnA1W1WVUXdnZ2BoQBAADDzHpKtvuSPJLkNVW1XVV3dvcLSe5K8lCSp5I80N1PzvPkZooBAFgFs5594twB45eSXLraJ9dTDADAKljqZZ7NFAMAsAqqu5cdQ6rqn5J8eglPfX2Szy3heTkc8nm0yOfRIp9Hi3weLWPL59d19/87H/BKFMXLUlWPdfeZZcfBYsjn0SKfR4t8Hi3yebTI566ltk8AAMAqUBQDADB6Yy+KLyw7ABZKPo8W+Txa5PNokc+jRT4z8p5iAABIzBQDAMB4i+KqOltVT1fV5ao6v+x42F9Vfaqq/q6qPlJVj03Gvrqq/qKqPjH5+lVTj//FSU6frqrvmhp//WQ7l6vqXVVVy/h5xqaq7qmq56vqiamxheWvql5eVX8wGf+bqjp5LX++sTkgn79SVf842Uc/UlVvnvqefK6wqrqpqv6qqp6qqier6mcn4/bRNXOFXNo/59Hdo1uSXJfkk0leneRYko8mOb3suCz75upTSa7fM/ZrSc5Pbp9P8s7J7dOTXL48yc2THF83+d6Hk3xzkkryZ0luW/bPNoYlyRuTvC7JE4eRvyQ/leTdk9t3JPmDZf/MR3k5IJ+/kuTn93msfK74kuRVSV43uf0VSf5+kjf76JotV8il/XOOZawzxbcmudzdz3T3F5Lcn+T2JcfE7G5P8juT27+T5Hunxu/v7v/o7n9IcjnJrVX1qiRf2d2P9O7e/LtT63CIuvvhJJ/fM7zI/E1v631Jvt2nAIfngHweRD5XXHd/prv/dnL7X5M8leR47KNr5wq5PIhc7mOsRfHxJM9O3d/OlV88LE8n+fOqeryqtiZjX9vdn0l23wiSfM1k/KC8Hp/c3jvOciwyfy+t090vJNlJ8spDi5yD3FVVH5u0V7z4Ubt8rpHJR+GvTfI3sY+utT25TOyfMxtrUbzffzZOw7GavrW7X5fktiQ/XVVvvMJjD8qrfK+Hq8mf3C7fbyf5+iTfmOQzSX59Mi6fa6KqvjzJHyX5ue7+lys9dJ8xOV0h++TS/jmHsRbF20lumrp/Y5LnlhQLV9Ddz02+Pp/kj7Pb+vLZyUc8mXx9fvLwg/K6Pbm9d5zlWGT+Xlqnql6WZCOzf7zPAnT3Z7v7v7r7v5O8J7v7aCKfa6GqvjS7RdTvd/f7J8P20TW0Xy7tn/MZa1H8aJJbqurmqjqW3YbxB5ccE3tU1Suq6itevJ3kO5M8kd1cvXXysLcm+dPJ7QeT3DE5QvbmJLck+fDk479/rapvmvQ//djUOlx7i8zf9LZ+MMlfTvrguEZeLJ4mvi+7+2ginytv8vt/b5Knuvs3pr5lH10zB+XS/jmnZR/pt6wlyZuze3TmJ5O8Y9nxWPbN0auze3TsR5M8+WKestvD9MEkn5h8/eqpdd4xyenTmTrDRJIz2X0z+GSS38zkwjWWQ8/hfdn9yO4/szvLcOci85fky5L8YXYPEvlwklcv+2c+yssB+fy9JH+X5GPZ/aP5KvlcjyXJt2X34++PJfnIZHmzfXT9livk0v45x+KKdgAAjN5Y2ycAAOAlimIAAEZPUQwAwOgpigEAGD1FMQAAo6coBgBg9BTFAACMnqIYAIDR+x9rsk5terlgegAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -611,12 +702,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQWklEQVR4nO3df4zkd1kH8PfDYTEpuBF6GnLteVe3aby/BDfFXyEkIl7BpYhEe5gIpuGCWqN/mHgEE/kTTfQPQoUcoSkY0lIrSk+OVIOSxqSBtqTAlcvJUUu6LeFEkpMYIxYe/9hpGdbb6+zN7M3sfl+vZLIzn53vd5655753z3zm+X6+1d0BAIAhe968AwAAgHlTFAMAMHiKYgAABk9RDADA4CmKAQAYPEUxAACD9/x5B5AkV111VR84cGDeYQAAsMs9/PDD3+juvRvHF6IoPnDgQB566KF5hwEAwC5XVV+90Lj2CQAABk9RDADA4M21KK6q1ao6fv78+XmGAQDAwM21KO7uE919dGlpaZ5hAAAwcNonAAAYvIVYfWJeDhz7xPc9fvzdr5tTJAAAzJOZYgAABk9RDADA4CmKAQAYvG0piqvqyqp6uKp+eTv2DwAAszRRUVxVt1fVuao6tWH8cFWdqaqzVXVs7Fd/lOTuWQYKAADbZdKZ4juSHB4fqKo9SW5LcmOSQ0mOVNWhqnp1ki8l+foM4wQAgG0z0ZJs3X1/VR3YMHxDkrPd/ViSVNVdSW5K8sIkV2a9UP7vqjrZ3d+dWcQAADBj06xTvC/JE2OP15K8ortvTZKqemuSb2xWEFfV0SRHk2T//v1ThAEAANOZ5kS7usBYP3un+47u/vvNNu7u49290t0re/funSIMAACYzjRF8VqSa8YeX53kqa3soKpWq+r4+fPnpwgDAACmM01R/GCS66rqYFVdkeTmJPfOJiwAALh8Jl2S7c4kDyS5vqrWquqW7n46ya1J7ktyOsnd3f3oVl68u09099GlpaWtxg0AADMz6eoTRzYZP5nk5KW+eFWtJlldXl6+1F0AAMDU5nqZZzPFAAAsgrkWxQAAsAjmWhRbfQIAgEWgfQIAgMEzUwwAwOCZKQYAYPCcaAcAwOApigEAGDw9xQAADJ6eYgAABk/7BAAAg6coBgBg8PQUAwAweHqKAQAYPO0TAAAMnqIYAIDBUxQDADB4imIAAAbP6hMAAAye1ScAABg87RMAAAyeohgAgMFTFAMAMHiKYgAABk9RDADA4M28KK6qn6iq91fVPVX127PePwAAzNpERXFV3V5V56rq1Ibxw1V1pqrOVtWxJOnu09399iS/lmRl9iEDAMBsTTpTfEeSw+MDVbUnyW1JbkxyKMmRqjo0+t3rk/xLkk/NLFIAANgmExXF3X1/km9uGL4hydnufqy7v53kriQ3jZ5/b3f/bJLfmGWwAACwHZ4/xbb7kjwx9ngtySuq6lVJ3pjkBUlObrZxVR1NcjRJ9u/fP0UYAAAwnWmK4rrAWHf3p5N8+rk27u7jSY4nycrKSk8RBwAATGWa1SfWklwz9vjqJE9tZQdVtVpVx8+fPz9FGAAAMJ1pZoofTHJdVR1M8mSSm5O8eSZRzcmBY5949v7j737dHCMBAOBymnRJtjuTPJDk+qpaq6pbuvvpJLcmuS/J6SR3d/ejW3nx7j7R3UeXlpa2GjcAAMzMRDPF3X1kk/GTucjJdM+lqlaTrC4vL1/qLgAAYGpzvcyzmWIAABbBXItiAABYBHMtiq0+AQDAItA+AQDA4E2zJNuuZnk2AIDh0D4BAMDgaZ8AAGDwrD4BAMDgaZ8AAGDwtE8AADB42icAABg8RTEAAIM313WKq2o1yery8vI8w3hO1iwGANjd9BQDADB42icAABg8RTEAAIOnKAYAYPAUxQAADJ6iGACAwXOZZwAABs+SbAAADN5cL96xE7mQBwDA7qOnGACAwVMUAwAweIpiAAAGT1EMAMDgbUtRXFVvqKoPVNXHq+o12/EaAAAwKxMXxVV1e1Wdq6pTG8YPV9WZqjpbVceSpLv/rrvfluStSX59phEDAMCMbWWm+I4kh8cHqmpPktuS3JjkUJIjVXVo7Cl/PPo9AAAsrInXKe7u+6vqwIbhG5Kc7e7HkqSq7kpyU1WdTvLuJJ/s7s9daH9VdTTJ0STZv3//1iNfANYsBgDYHabtKd6X5Imxx2ujsd9L8uokb6qqt19ow+4+3t0r3b2yd+/eKcMAAIBLN+0V7eoCY93d70nynufcuGo1yery8vKUYcAw+bYCAGZj2qJ4Lck1Y4+vTvLUpBt394kkJ1ZWVt42ZRwweApkALh00xbFDya5rqoOJnkyyc1J3jzpxmaKYXuMF8jjFMsAcGETF8VVdWeSVyW5qqrWkvxJd3+wqm5Ncl+SPUlu7+5HJ92nmWLYus0KXgDg0m1l9Ykjm4yfTHLyUl7cTDFDMkkxu90zuZu1WJhZBmDopm2fmIqZYna7aWZ1t3tG2IwzAHzPXIvi3TRT7CSn4dnqrOtON+nfcbPRAOxEZoqBTU1S4M/yQ4APlwDMy1yLYthJLlb87dbZ4c1M+n6H9ucCwM6lfQIu4nIXdUMsIof4ngFYPNonIAqz3UDrBQDT0D4BLKRpTsxTIAOwVdongB3LDD8As6J9YhuYpYLF5NgEYDPPm3cAAAAwb3qK2ZUmuYCEmcKdaVYtE/4uADBOUQwMngIZACfasWtsNoPoZCxmQeEMsLs50Q7Y1bb6ociHKIBh0j7BjjZNAaP4YdbMJgPsXIpigC3ygQpg97EkGwAAg2emmIXlq2gA4HKx+gQ7jq+u2Ym2una2D4UAl5fVJwAuMx/sABaPnmIAAAZPTzHANpjlbLBWCoDtpygGWBDaKgDmR1G8zczwAAAsPkUxC2WzmTIzaDA5H8YBtm7mJ9pV1bVV9cGqumfW+wYAgO0wUVFcVbdX1bmqOrVh/HBVnamqs1V1LEm6+7HuvmU7ggUAgO0wafvEHUnem+TDzwxU1Z4ktyX5xSRrSR6sqnu7+0uzDnK38JUmAMBimqgo7u77q+rAhuEbkpzt7seSpKruSnJTkomK4qo6muRokuzfv3/CcAG4EH33ANOZpqd4X5Inxh6vJdlXVS+pqvcneVlVvWOzjbv7eHevdPfK3r17pwgDAACmM83qE3WBse7u/0jy9ol2ULWaZHV5eXmKMACGaTtmh7V5AUM1zUzxWpJrxh5fneSpreygu09099GlpaUpwgAAgOlMM1P8YJLrqupgkieT3JzkzVvZgZnidUOZmRnK+4TttGi9w45rYLeYdEm2O5M8kOT6qlqrqlu6++kktya5L8npJHd396NbeXEzxQAALIJJV584ssn4ySQnL/XFhzxTvGizPQCT8u8XsBvN/Ip2W2GmGACARTBNT/HUhjxTDHA5bDarq/8X4PuZKQYAYPDmWhQDAMAi0D4BMHCbtVgsygl1ln0DLgftEwAADJ72CQAABk/7xIIZyteEi/K1LHB5bTz2d/O/c8DOon0CAIDB0z4BAMDgKYoBABg8RTEAAIPnRDtmwolzwCxPFJ5k7eTx19jqa89qP8Du4UQ7AAAGT/sEAACDpygGAGDwFMUAAAyeohgAgMGz+gRJLu2MaytOwM613cfvpPvfjjg22+dWV5NYlJUoFiWOrdiJMYPVJwAAGDztEwAADJ6iGACAwVMUAwAweIpiAAAGT1EMAMDgzXxJtqq6MslfJvl2kk9390dm/RoAADBLE80UV9XtVXWuqk5tGD9cVWeq6mxVHRsNvzHJPd39tiSvn3G8AAAwc5O2T9yR5PD4QFXtSXJbkhuTHEpypKoOJbk6yROjp31nNmECAMD2mah9orvvr6oDG4ZvSHK2ux9Lkqq6K8lNSdayXhg/kosU3VV1NMnRJNm/f/9W4x6ESa4ItNlzJrmi02bPudgVplyZCFgUW70a3qX8m/dcz5/lVfK2a7+X+vxJ/n+Z1WtNu/2snjON3XAVv6H/GU1zot2+fG9GOFkvhvcl+ViSX62q9yU5sdnG3X28u1e6e2Xv3r1ThAEAANOZ5kS7usBYd/d/JfmtiXZQtZpkdXl5eYowAABgOtPMFK8luWbs8dVJntrKDrr7RHcfXVpamiIMAACYzjRF8YNJrquqg1V1RZKbk9y7lR1U1WpVHT9//vwUYQAAwHQmXZLtziQPJLm+qtaq6pbufjrJrUnuS3I6yd3d/ehWXtxMMQAAi2DS1SeObDJ+MsnJS31xPcUAACyCuV7m2UwxAACLoLp73jGkqv49yVfn8NJXJfnGHF6Xy0ueh0Gedz85HgZ5HoZ55vnHuvv/rQe8EEXxvFTVQ929Mu842F7yPAzyvPvJ8TDI8zAsYp7n2j4BAACLQFEMAMDgDb0oPj7vALgs5HkY5Hn3k+NhkOdhWLg8D7qnGAAAEjPFAAAw3KK4qg5X1ZmqOltVx+YdD1tTVY9X1Rer6pGqemg09uKq+seq+vLo5w+PPf8do1yfqapfGhv/qdF+zlbVe6qq5vF+WFdVt1fVuao6NTY2s7xW1Quq6qOj8c9U1YHL+f5Yt0me31VVT46O6Ueq6rVjv5PnHaaqrqmqf66q01X1aFX9/mjc8byLXCTPO/N47u7B3ZLsSfKVJNcmuSLJ55McmndcblvK4eNJrtow9mdJjo3uH0vyp6P7h0Y5fkGSg6Pc7xn97rNJfiZJJflkkhvn/d6GfEvyyiQvT3JqO/Ka5HeSvH90/+YkH533ex7ibZM8vyvJH17gufK8A29JXprk5aP7L0ryr6NcOp530e0ied6Rx/NQZ4pvSHK2ux/r7m8nuSvJTXOOiendlORDo/sfSvKGsfG7uvt/uvvfkpxNckNVvTTJD3X3A71+tH14bBvmoLvvT/LNDcOzzOv4vu5J8gu+Hbj8NsnzZuR5B+rur3X350b3v5XkdJJ9cTzvKhfJ82YWOs9DLYr3JXli7PFaLp5EFk8n+Yeqeriqjo7GfrS7v5asH6hJfmQ0vlm+943ubxxnscwyr89u091PJzmf5CXbFjlbdWtVfWHUXvHM1+ryvMONvu5+WZLPxPG8a23Ic7IDj+ehFsUX+oRhGY6d5ee6++VJbkzyu1X1yos8d7N8+3uws11KXuV8cb0vyY8n+ckkX0vy56Nxed7BquqFSf4myR90939e7KkXGJPnHeICed6Rx/NQi+K1JNeMPb46yVNzioVL0N1PjX6eS/K3WW+J+froK5iMfp4bPX2zfK+N7m8cZ7HMMq/PblNVz0+ylMm/xmcbdffXu/s73f3dJB/I+jGdyPOOVVU/kPVC6SPd/bHRsON5l7lQnnfq8TzUovjBJNdV1cGquiLrjdv3zjkmJlRVV1bVi565n+Q1SU5lPYdvGT3tLUk+Prp/b5KbR2ewHkxyXZLPjr66+1ZV/fSoP+k3x7Zhccwyr+P7elOSfxr1rzFnzxRKI7+S9WM6kecdaZSTDyY53d1/MfYrx/Muslmed+zxfDnOTlzEW5LXZv0sya8keee843HbUu6uzfrZq59P8ugz+ct6j9Gnknx59PPFY9u8c5TrMxlbYSLJStYP1q8keW9GF7Rxm1tu78z6V23/m/XZgVtmmdckP5jkr7N+csdnk1w77/c8xNsmef6rJF9M8oWs/yf4UnneubckP5/1r7i/kOSR0e21jufddbtInnfk8eyKdgAADN5Q2ycAAOBZimIAAAZPUQwAwOApigEAGDxFMQAAg6coBgBg8BTFAAAMnqIYAIDB+z+d+Vi1GM4lpwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQYElEQVR4nO3db4xld1kH8O9DcTEpOBFaDdl23eI2jftKYFP8F2IiwS04FJFoFxPBNN2g1ugLE5fgC16Cib4gVsgSmqIhLbWidMOSalDSmDTQlhRo2awstaRDG1okWYkx1sLji7kt13Fne2fPnb135nw+yc3c+5t7zn1mnz27z/zOc36nujsAADBmL1p0AAAAsGiKYgAARk9RDADA6CmKAQAYPUUxAACjpygGAGD0XrzoAJLksssu6/379y86DAAAdrkHH3zw2919+cbxpSiK9+/fnwceeGDRYQAAsMtV1TfONa59AgCA0VMUAwAwegstiqtqtaqOnz17dpFhAAAwcgstirv7RHcfXVlZWWQYAACMnPYJAABGbylWn1iU/cc+/X9eP/b+Ny8oEgAAFslMMQAAo6coBgBg9BTFAACM3rYUxVV1aVU9WFW/sh37BwCAeZqpKK6qW6vqqap6eMP44ao6XVVnqurY1Lf+OMmd8wwUAAC2y6wzxbclOTw9UFWXJLklyXVJDiY5UlUHq+oNSb6a5FtzjBMAALbNTEuydfe9VbV/w/C1Sc5096NJUlV3JLk+yUuTXJr1Qvm/qupkd39/bhEDAMCcDVmneG+Sx6deryV5XXffnCRV9a4k396sIK6qo0mOJsm+ffsGhAEAAMMMKYrrHGP9/JPu2863cXcfr6onk6zu2bPntQPiAACAQYasPrGW5Mqp11ckeWIrO+juE919dGVlZUAYAAAwzJCi+P4kV1fVVVW1J8kNSe7eyg6qarWqjp89e3ZAGAAAMMysS7LdnuS+JNdU1VpV3djdzya5Ock9SU4lubO7H9nKh5spBgBgGcy6+sSRTcZPJjl5oR9eVatJVg8cOHChuwAAgMEWeptnM8UAACyDhRbFAACwDBZaFLvQDgCAZaB9AgCA0TNTDADA6JkpBgBg9FxoBwDA6CmKAQAYPT3FAACMnp5iAABGT/sEAACjpygGAGD09BQDADB6eooBABg97RMAAIyeohgAgNFTFAMAMHqKYgAARs/qEwAAjJ7VJwAAGD3tEwAAjJ6iGACA0VMUAwAweopiAABGT1EMAMDozb0orqqfqqoPV9VdVfU7894/AADM20xFcVXdWlVPVdXDG8YPV9XpqjpTVceSpLtPdfe7k/x6kkPzDxkAAOZr1pni25Icnh6oqkuS3JLkuiQHkxypqoOT770lyb8k+ezcIgUAgG0yU1Hc3fcm+c6G4WuTnOnuR7v7mSR3JLl+8v67u/vnkvzmPIMFAIDt8OIB2+5N8vjU67Ukr6uqX0zytiQvSXJys42r6miSo0myb9++AWEAAMAwQ4riOsdYd/fnknzuhTbu7uNV9WSS1T179rx2QBwAADDIkKJ4LcmVU6+vSPLEVnbQ3SeSnDh06NBNA+KYm/3HPv3888fe/+YFRgIAwMU0ZEm2+5NcXVVXVdWeJDckuXsrO6iq1ao6fvbs2QFhAADAMLMuyXZ7kvuSXFNVa1V1Y3c/m+TmJPckOZXkzu5+ZCsf3t0nuvvoysrKVuMGAIC5mal9oruPbDJ+Mue5mO6FVNVqktUDBw5c6C4AAGCwhd7m2UwxAADLYKFFMQAALIOFFsUutAMAYBlonwAAYPSGrFM82DJfaGfNYgCA8TBTDADA6LnQDgCA0VMUAwAwelafAABg9PQUAwAwetonAAAYPUUxAACjZ53iGVizGABgd9NTDADA6GmfAABg9BTFAACMnqIYAIDRUxQDADB67mgHAMDoWX0CAIDR0z4BAMDoKYoBABi9hd7RbidydzsAgN3HTDEAAKOnKAYAYPS2pSiuqrdW1Ueq6lNV9cbt+AwAAJiXmYviqrq1qp6qqoc3jB+uqtNVdaaqjiVJd/99d9+U5F1JfmOuEQMAwJxtZab4tiSHpweq6pIktyS5LsnBJEeq6uDUW/5k8n0AAFhaMxfF3X1vku9sGL42yZnufrS7n0lyR5Lra90Hknymu784v3ABAGD+hvYU703y+NTrtcnY7yd5Q5K3V9W7z7VhVR2tqgeq6oGnn356YBgAAHDhhq5TXOcY6+7+YJIPnm/D7j6e5HiSHDp0qAfGsRDWLAYA2B2GzhSvJbly6vUVSZ6YdeOqWq2q42fPnh0YBgAAXLihM8X3J7m6qq5K8s0kNyR5x+CogJlMn62Y5swFAGzNVpZkuz3JfUmuqaq1qrqxu59NcnOSe5KcSnJndz8y6z67+0R3H11ZWdlq3MCM9h/79PMPAODcZp4p7u4jm4yfTHLyQj68qlaTrB44cOBCNodRmqW4VQADwNYMbZ8YpLtPJDlx6NChmxYZB1xsi2p7mOXiUBeQAjBGCy2KYbcbMmO73cWp2WQA+IGFFsXaJ9jJLuaM6jIUsLP+vJu9z0WBACwz7RNz4pQzz1mGAnZe9C8DMBbaJ2BG5yv+xlYYzvrzbvXPxS+XACyK9gk4j4td7I6tuAaAZaF9AqIYXaR5/dmbZQZgCO0TwFIacmGeAhmArdI+AexYZvgBmBftE9vALBUAwM6ifQIYDb+wArAZRTG70iw3kFAU7UwuzANgO+gpZtfYrFjSd8oLmaVAVkQD7G56igGmKH4Bxkn7BLCrOVMAwCwUxexoCh62k9tUA4yHopjRUlBzofzdAdh9XrToAAAAYNHMFLO0nIoGAC4WS7Kx4zh1zW5iTW2A5WBJNoCLwC9zAMtNTzEAAKOnpxhgG8xzZlgrBcD2UxQDLAktFgCLoyjeZmZ4AACWn6KYpbLZTJkZNJidX8YBtm7uF9pV1auq6qNVdde89w0AANthpqK4qm6tqqeq6uEN44er6nRVnamqY0nS3Y92943bESwAAGyHWWeKb0tyeHqgqi5JckuS65IcTHKkqg7ONToAALgIZuop7u57q2r/huFrk5zp7keTpKruSHJ9kq/Oss+qOprkaJLs27dvxnB3Nn1+wHbRdw8wzJCe4r1JHp96vZZkb1W9oqo+nOTVVfWezTbu7uPdfai7D11++eUDwgAAgGGGrD5R5xjr7v73JO+eaQdVq0lWDxw4MCAMgHHajtlhZ7SAsRoyU7yW5Mqp11ckeWIrO+juE919dGVlZUAYAAAwzJCZ4vuTXF1VVyX5ZpIbkrxjKzswUzwuZqBguGXrHXZcA7vFrEuy3Z7kviTXVNVaVd3Y3c8muTnJPUlOJbmzux/ZyoebKQYAYBnMuvrEkU3GTyY5eaEfPuaZ4s1me8y0AMtu2WarAeZh7ne02wozxQAALIMhPcWDjXmmGOBicFYKYDZmigEAGL2FFsUAALAMtE8AjNxmLRbLckGdZd+Ai0H7BAAAo6d9AgCA0dM+sWTGcppwWU7LAhfXxmN/N/87B+ws2icAABg97RMAAIyeohgAgNFTFAMAMHoutGMuXDgHzPNC4VnWTp7+jK1+9rz2A+weLrQDAGD0tE8AADB6imIAAEZPUQwAwOgpigEAGD2rT5Dkwq64tuIE7FzbffzOuv/tiGOzfW51NYllWYliWeLYip0YM1h9AgCA0dM+AQDA6CmKAQAYPUUxAACjpygGAGD0FMUAAIze3Jdkq6pLk/xlkmeSfK67Pz7vzwAAgHmaaaa4qm6tqqeq6uEN44er6nRVnamqY5PhtyW5q7tvSvKWOccLAABzN2v7xG1JDk8PVNUlSW5Jcl2Sg0mOVNXBJFckeXzytu/NJ0wAANg+M7VPdPe9VbV/w/C1Sc5096NJUlV3JLk+yVrWC+OHcp6iu6qOJjmaJPv27dtq3KMwyx2BNnvPLHd02uw957vDlDsTActiq3fDu5B/817o/fO8S9527fdC3z/L/y/z+qyh28/rPUPshrv4jf3PaMiFdnvzgxnhZL0Y3pvkk0l+rao+lOTEZht39/HuPtTdhy6//PIBYQAAwDBDLrSrc4x1d/9nkt+eaQdVq0lWDxw4MCAMAAAYZshM8VqSK6deX5Hkia3soLtPdPfRlZWVAWEAAMAwQ4ri+5NcXVVXVdWeJDckuXsrO6iq1ao6fvbs2QFhAADAMLMuyXZ7kvuSXFNVa1V1Y3c/m+TmJPckOZXkzu5+ZCsfbqYYAIBlMOvqE0c2GT+Z5OSFfrieYgAAlsFCb/NsphgAgGVQ3b3oGFJVTyf5xgI++rIk317A53JxyfM4yPPuJ8fjIM/jsMg8/0R3/7/1gJeiKF6Uqnqguw8tOg62lzyPgzzvfnI8DvI8DsuY54W2TwAAwDJQFAMAMHpjL4qPLzoALgp5Hgd53v3keBzkeRyWLs+j7ikGAIDETDEAAIy3KK6qw1V1uqrOVNWxRcfD1lTVY1X1lap6qKoemIy9vKr+saq+Nvn6o1Pvf88k16er6penxl872c+ZqvpgVdUifh7WVdWtVfVUVT08NTa3vFbVS6rqE5Pxz1fV/ov587Fukzy/r6q+OTmmH6qqN019T553mKq6sqr+uapOVdUjVfUHk3HH8y5ynjzvzOO5u0f3SHJJkq8neVWSPUm+lOTgouPy2FIOH0ty2YaxP01ybPL8WJIPTJ4fnOT4JUmumuT+ksn3vpDkZ5NUks8kuW7RP9uYH0len+Q1SR7ejrwm+d0kH548vyHJJxb9M4/xsUme35fkj87xXnnegY8kr0zymsnzlyX510kuHc+76HGePO/I43msM8XXJjnT3Y929zNJ7khy/YJjYrjrk3xs8vxjSd46NX5Hd/93d/9bkjNJrq2qVyb5ke6+r9ePtr+a2oYF6O57k3xnw/A88zq9r7uS/JKzAxffJnnejDzvQN39ZHd/cfL8u0lOJdkbx/Oucp48b2ap8zzWonhvksenXq/l/Elk+XSSf6iqB6vq6GTsx7v7yWT9QE3yY5PxzfK9d/J84zjLZZ55fX6b7n42ydkkr9i2yNmqm6vqy5P2iudOq8vzDjc53f3qJJ+P43nX2pDnZAcez2Mtis/1G4ZlOHaWn+/u1yS5LsnvVdXrz/PezfLt78HOdiF5lfPl9aEkP5nkp5M8meTPJuPyvINV1UuT/G2SP+zu/zjfW88xJs87xDnyvCOP57EWxWtJrpx6fUWSJxYUCxegu5+YfH0qyd9lvSXmW5NTMJl8fWry9s3yvTZ5vnGc5TLPvD6/TVW9OMlKZj+Nzzbq7m919/e6+/tJPpL1YzqR5x2rqn4o64XSx7v7k5Nhx/Muc64879TjeaxF8f1Jrq6qq6pqT9Ybt+9ecEzMqKouraqXPfc8yRuTPJz1HL5z8rZ3JvnU5PndSW6YXMF6VZKrk3xhcuruu1X1M5P+pN+a2oblMc+8Tu/r7Un+adK/xoI9VyhN/GrWj+lEnnekSU4+muRUd//51Lccz7vIZnnescfzxbg6cRkfSd6U9askv57kvYuOx2NLuXtV1q9e/VKSR57LX9Z7jD6b5GuTry+f2ua9k1yfztQKE0kOZf1g/XqSv8jkhjYeC8vt7Vk/1fY/WZ8duHGeeU3yw0n+JusXd3whyasW/TOP8bFJnv86yVeSfDnr/wm+Up537iPJL2T9FPeXkzw0ebzJ8by7HufJ8448nt3RDgCA0Rtr+wQAADxPUQwAwOgpigEAGD1FMQAAo6coBgBg9BTFAACMnqIYAIDRUxQDADB6/wtrdFYG/Ht1dwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -638,12 +729,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQRklEQVR4nO3db4xld1kH8O/DYokpOEFbCNl23eI2jRte8GdSVBLCC9StsBTxT7oYRdMwQqjRFyYWNYE3xmrUBGKFrNAUEmzTIGBXFosxksak0W4JSsumutZihzYUJFmJMZLC44u9hWHYWe7dc2funTmfT3Kz9/zmnnOeu8+ezZPfPOd3qrsDAABj9oxFBwAAAIumKAYAYPQUxQAAjJ6iGACA0VMUAwAweopiAABG75mLDiBJLrvssj548OCiwwAAYI974IEHvtzdl28eX4qi+ODBgzl16tSiwwAAYI+rqs+fb1z7BAAAo7fQoriqjlbV8bNnzy4yDAAARm6hRXF3n+jutZWVlUWGAQDAyGmfAABg9BTFAACM3lKsPrEoB2/++LdtP3rLaxYUCQAAi2SmGACA0VMUAwAwettSFFfVpVX1QFW9djuODwAA8zRVUVxVt1XVk1X14KbxI1X1cFWdqaqbN/zot5LcNc9AAQBgu0w7U3x7kiMbB6pqX5Jbk1yX5HCSY1V1uKpeneRzSb44xzgBAGDbTLX6RHffW1UHNw1fm+RMdz+SJFV1Z5Lrkzw7yaU5Vyj/b1Wd7O5vzC1iAACYsyFLsu1P8tiG7fUkL+/um5Kkqn45yZe3Koirai3JWpIcOHBgQBgAADDMkBvt6jxj/c033bd3919vtXN3H+/u1e5evfzyyweEAQAAwwwpiteTXLlh+4okj89ygKo6WlXHz549OyAMAAAYZkhRfH+Sq6vqqqq6JMkNSe6eT1gAALBzpl2S7Y4k9yW5pqrWq+rG7n4qyU1J7klyOsld3f3QLCfv7hPdvbaysjJr3AAAMDfTrj5xbIvxk0lOzjUiAADYYQt9zLOeYgAAlsFCi2LtEwAALAMzxQAAjJ6ZYgAARm+hRTEAACwD7RMAAIye9gkAAEZP+wQAAKOnfQIAgNHTPgEAwOhpnwAAYPQUxQAAjJ6iGACA0XOjHQAAo+dGOwAARk/7BAAAo6coBgBg9BTFAACMnqIYAIDRs/oEAACjZ/UJAABGT/sEAACjpygGAGD0FMUAAIyeohgAgNFTFAMAMHpzL4qr6oer6r1V9eGqeuu8jw8AAPM2VVFcVbdV1ZNV9eCm8SNV9XBVnamqm5Oku09391uS/HyS1fmHDAAA8zXtTPHtSY5sHKiqfUluTXJdksNJjlXV4cnPXpfkH5L83dwiBQCAbTJVUdzd9yb5yqbha5Oc6e5HuvtrSe5Mcv3k83d3948l+YWtjllVa1V1qqpOfelLX7q46AEAYA6eOWDf/Uke27C9nuTlVfWqJG9I8qwkJ7faubuPJzmeJKurqz0gDgAAGGRIUVznGevu/lSST011gKqjSY4eOnRoQBgAADDMkNUn1pNcuWH7iiSPz3KA7j7R3WsrKysDwgAAgGGGFMX3J7m6qq6qqkuS3JDk7lkOUFVHq+r42bNnB4QBAADDTLsk2x1J7ktyTVWtV9WN3f1UkpuS3JPkdJK7uvuhWU6+G2eKD9788W++AADYG6bqKe7uY1uMn8wFbqb7bvQUAwCwDIbcaDdYd59IcmJ1dfXNi4zjYm2cLX70ltcsMBIAAIaY+2OeZ6GnGACAZbDQong39hQDALD3LLQoBgCAZbDQnuLdcqPdNCtN6C8GANi9tE8AADB62icAABg9q08AADB62icAABg97RMAAIzeQlef2KusRAEAsLuYKQYAYPTcaAcAwOi50Q4AgNHTPgEAwOgpigEAGD1FMQAAo6coBgBg9Ba6TnFVHU1y9NChQ4sMY1tZsxgAYPlZfQIAgNHzRLsdZNYYAGA5KYq3sLGABQBgb3OjHQAAo2emeIlptwAA2BmK4g12smVCwQsAsDy2pSiuqtcneU2S5yW5tbs/uR3n2StmLZC3Kt4V1wAAF2fqoriqbkvy2iRPdveLNowfSfKuJPuSvK+7b+nujyX5WFU9N8kfJVEUT2mrgteNfwAA22eWmeLbk/xpkg8+PVBV+5LcmuTHk6wnub+q7u7uz00+8ruTn7MDtGQAAFycqYvi7r63qg5uGr42yZnufiRJqurOJNdX1ekktyT5RHd/ek6xMgMFMgDA9Ib2FO9P8tiG7fUkL0/ya0lenWSlqg5193s371hVa0nWkuTAgQMDw+BCFMgAABc2tCiu84x1d787ybsvtGN3H6+qJ5IcveSSS142MA6mpEAGAPhOQ4vi9SRXbti+Isnj0+7c3SeSnFhdXX3zwDgYSLEMAIzZ0KL4/iRXV9VVSb6Q5IYkb5x256o6muTooUOHBobBPG1e6UKRDADsdbMsyXZHklcluayq1pO8o7vfX1U3Jbkn55Zku627H5r2mGaKF8sybwAA58yy+sSxLcZPJjl5MSc3UwwAwDJ4xiJP3t0nunttZWVlkWEAADBy2/KYZ/YuN+QBAHvRQmeKq+poVR0/e/bsIsMAAGDkqrsXHUNWV1f71KlTO35eN5rNz8ZZY7PJAMCyqqoHunt18/hC2yfcaLf3TVMgK6IBgEVbaFFsSbbxMksPACyThfYUAwDAMrD6BHMxr5lfrRQAwCJYfQIAgNHTU8yO0UcMACwr7RPsOkNaLLRnAADnoyhmVzDLDABsJ+sUs+cpqAGA72ahN9p194nuXltZWVlkGAAAjJz2CfakaWaH9RcDAE9TFLO0Zm170CYBAFwsRTG7mkIYAJgHj3kGAGD0rD4Bc7bV7LW+ZQBYXp5oBwvgJj8AWC7aJwAAGD1FMQAAo2f1CdjkYlobtnsVDO0WALC9FMWQ2R/2AQDsLYpi2CGKagBYXnMviqvqhUl+J8lKd//svI8PY6eVAgDmb6qiuKpuS/LaJE9294s2jB9J8q4k+5K8r7tv6e5HktxYVR/ejoBhJ5ndBYBxmHb1iduTHNk4UFX7ktya5Lokh5Mcq6rDc40OAAB2wFQzxd19b1Ud3DR8bZIzk5nhVNWdSa5P8rl5BghjZZYaAHbOkJ7i/Uke27C9nuTlVfUDSX4vyUuq6u3d/fvn27mq1pKsJcmBAwcGhAG725Ae4UXtCwB7zZCiuM4z1t39X0ne8t127u7jSY4nyerqag+IAwAABhlSFK8nuXLD9hVJHp/lAFV1NMnRQ4cODQgDmNYytmSYsQZgGQwpiu9PcnVVXZXkC0luSPLGuUQFLIwiFYAxmmr1iaq6I8l9Sa6pqvWqurG7n0pyU5J7kpxOcld3PzTLybv7RHevrayszBo3AADMzbSrTxzbYvxkkpNzjQgAAHbYQh/zrKcY5kfbAwBcvGkf3rEttE8AALAMzBTDHjfNihNDVqXYvO9Ws9RmsgFYZmaKAQAYvYUWxQAAsAy0T8ASWbaHa+yFlodZv8Ne+M4AzE77BAAAo6d9AgCA0dM+AUxlp9sKZm0l2RjTrCtuLHtbhZYOgO2nfQIAgNHTPgEAwOgpigEAGD1FMQAAo+dGO9iDlm29491qyCOyN98Qt903y7kZD2AYN9oBADB62icAABg9RTEAAKOnKAYAYPQUxQAAjJ7VJ4CZXWhVhiGrIAxZNWPIShHLcq6dXDVkL6xWsZPfYS/8fQEXZvUJAABGT/sEAACjpygGAGD0FMUAAIyeohgAgNFTFAMAMHpzX5Ktqi5N8mdJvpbkU939oXmfAwAA5mmqmeKquq2qnqyqBzeNH6mqh6vqTFXdPBl+Q5IPd/ebk7xuzvECAMDcTds+cXuSIxsHqmpfkluTXJfkcJJjVXU4yRVJHpt87OvzCRMAALbPVO0T3X1vVR3cNHxtkjPd/UiSVNWdSa5Psp5zhfFncoGiu6rWkqwlyYEDB2aNG9gFtnpC204+uW0Z7eST+zY+fW2afGz1tLZpjjnrvhcy63dYNkP+vnbrubfKzdBzeZrg7rBd/xfspCE32u3Pt2aEk3PF8P4kH0nyM1X1niQnttq5u49392p3r15++eUDwgAAgGGG3GhX5xnr7v6fJL8y1QGqjiY5eujQoQFhAADAMENmiteTXLlh+4okj89ygO4+0d1rKysrA8IAAIBhhhTF9ye5uqquqqpLktyQ5O5ZDlBVR6vq+NmzZweEAQAAw0y7JNsdSe5Lck1VrVfVjd39VJKbktyT5HSSu7r7oVlObqYYAIBlMO3qE8e2GD+Z5OTFnlxPMQAAy2Chj3k2UwwAwDKo7l50DKmqLyX5/AJOfVmSLy/gvAwnd7uTvO1ecrc7ydvuJXfb5we7+zvWA16KonhRqupUd68uOg5mJ3e7k7ztXnK3O8nb7iV3O2+h7RMAALAMFMUAAIze2Ivi44sOgIsmd7uTvO1ecrc7ydvuJXc7bNQ9xQAAkJgpBgCA8RbFVXWkqh6uqjNVdfOi4+HbVdWjVfXZqvpMVZ2ajH1/Vf1tVf3b5M/nbvj82ye5fLiqfnJxkY9PVd1WVU9W1YMbxmbOVVW9bJLzM1X17qqqnf4uY7JF3t5ZVV+YXHefqaqf2vAzeVsCVXVlVf19VZ2uqoeq6tcn4665JXeB3LnulkV3j+6VZF+Sf0/ywiSXJPnnJIcXHZfXt+Xo0SSXbRr7wyQ3T97fnOQPJu8PT3L4rCRXTXK7b9HfYSyvJK9M8tIkDw7JVZJ/SvKjSSrJJ5Jct+jvtpdfW+TtnUl+8zyflbcleSV5QZKXTt4/J8m/TvLjmlvy1wVy57pbktdYZ4qvTXKmux/p7q8luTPJ9QuOie/u+iQfmLz/QJLXbxi/s7v/r7v/I8mZnMsxO6C7703ylU3DM+Wqql6Q5Pu6+74+9z/+BzfswzbYIm9bkbcl0d1PdPenJ++/muR0kv1xzS29C+RuK3K3w8ZaFO9P8tiG7fVc+B8mO6+TfLKqHqiqtcnY87v7ieTcfy5JnjcZl8/lM2uu9k/ebx5n591UVf8yaa94+lfw8raEqupgkpck+ce45naVTblLXHdLYaxF8fl6byzDsVxe0d0vTXJdkrdV1Ssv8Fn53D22ypUcLof3JPmhJC9O8kSSP56My9uSqapnJ/nLJL/R3f99oY+eZ0zuFug8uXPdLYmxFsXrSa7csH1FkscXFAvn0d2PT/58MslHc64d4ouTXxtl8ueTk4/L5/KZNVfrk/ebx9lB3f3F7v56d38jyZ/nW21I8rZEqup7cq6o+lB3f2Qy7JrbBc6XO9fd8hhrUXx/kqur6qqquiTJDUnuXnBMTFTVpVX1nKffJ/mJJA/mXI7eNPnYm5L81eT93UluqKpnVdVVSa7OuZsQWJyZcjX5de9Xq+pHJndR/9KGfdghTxdVEz+dc9ddIm9LY/L3/P4kp7v7Tzb8yDW35LbKnetueTxz0QEsQnc/VVU3Jbkn51aiuK27H1pwWHzL85N8dLLCzDOT/EV3/01V3Z/krqq6Mcl/Jvm5JOnuh6rqriSfS/JUkrd199cXE/r4VNUdSV6V5LKqWk/yjiS3ZPZcvTXJ7Um+N+fupv7EDn6N0dkib6+qqhfn3K9iH03yq4m8LZlXJPnFJJ+tqs9Mxn47rrndYKvcHXPdLQdPtAMAYPTG2j4BAADfpCgGAGD0FMUAAIyeohgAgNFTFAMAMHqKYgAARk9RDADA6CmKAQAYvf8HS0htCCOt2aUAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQNElEQVR4nO3db4xld1kH8O/j1iWm4ARtIWTbdYvTNG54wZ9Nq5KQvkDdCkMR/6SLUTQNK4QafWFiURN4Y6xGTSBWyAqbQoJtGgTshsVijKQxaXRbUqVlU11rsUMbWiRZiTGSwuOLvYVh2Fnu7Lkz986czye52Xt+c885z91nz+bJb57zO9XdAQCAMfueeQcAAADzpigGAGD0FMUAAIyeohgAgNFTFAMAMHqKYgAARu+SeQeQJJdddlkfOHBg3mEAALDLPfjgg1/u7svXjy9EUXzgwIE88MAD8w4DAIBdrqq+cL5x7RMAAIzeXIviqlqpqmNnz56dZxgAAIzcXIvi7j7R3UeXlpbmGQYAACOnfQIAgNFTFAMAMHoLsfrEvBy49ZPftv34ba+bUyQAAMyTmWIAAEZPUQwAwOhtSVFcVZdW1YNV9fqtOD4AAMzSVEVxVR2vqqer6uF144er6tGqOlNVt6750W8nuXuWgQIAwFaZdqb4jiSH1w5U1Z4ktye5IcnBJEeq6mBVvTbJ55N8aYZxAgDAlplq9Ynuvq+qDqwbvjbJme5+LEmq6q4kNyZ5fpJLc65Q/t+qOtnd35hZxAAAMGNDlmTbl+SJNdurSa7r7luSpKp+JcmXNyqIq+pokqNJsn///gFhAADAMEOK4jrPWH/zTfcdF9q5u49V1VNJVvbu3fuqAXEAAMAgQ1afWE1y5ZrtK5I8uZkDdPeJ7j66tLQ0IAwAABhmSFF8KsnVVXVVVe1NclOSezZzgKpaqapjZ8+eHRAGAAAMM+2SbHcmuT/JNVW1WlU3d/ezSW5Jcm+S00nu7u5HNnNyM8UAACyCaVefOLLB+MkkJy/25FW1kmRleXn5Yg8BAACDzfUxz2aKAQBYBHMtigEAYBHMtSh2ox0AAItA+wQAAKNnphgAgNEzUwwAwOi50Q4AgNFTFAMAMHp6igEAGD09xQAAjJ72CQAARk9RDADA6OkpBgBg9PQUAwAwetonAAAYPUUxAACjpygGAGD0FMUAAIyeohgAgNGzJBsAAKNnSTYAAEZP+wQAAKOnKAYAYPQUxQAAjJ6iGACA0VMUAwAwejMviqvqR6rq/VX10ap6+6yPDwAAszZVUVxVx6vq6ap6eN344ap6tKrOVNWtSdLdp7v7bUl+Icmh2YcMAACzNe1M8R1JDq8dqKo9SW5PckOSg0mOVNXByc/ekOQfkvzdzCIFAIAtMlVR3N33JfnKuuFrk5zp7se6+2tJ7kpy4+Tz93T3jyf5xY2OWVVHq+qBqnrgmWeeubjoAQBgBi4ZsO++JE+s2V5Ncl1VXZ/kTUmel+TkRjt397Ekx5Lk0KFDPSAOAAAYZEhRXOcZ6+7+TJLPTHWAqpUkK8vLywPCAACAYYasPrGa5Mo121ckeXIzB+juE919dGlpaUAYAAAwzJCi+FSSq6vqqqram+SmJPds5gBVtVJVx86ePTsgDAAAGGbaJdnuTHJ/kmuqarWqbu7uZ5PckuTeJKeT3N3dj2zm5DtxpvjArZ/85gsAgN1hqp7i7j6ywfjJXOBmuu9GTzEAAItgyI12g3X3iSQnDh069NZ5xnGx1s4WP37b6+YYCQAAQ8z8Mc+boacYAIBFMNeieCf2FAMAsPvMtSgGAIBFMNee4p1yo900K03oLwYA2Lm0TwAAMHraJwAAGD2rTwAAMHraJwAAGD3tEwAAjN5cV5/YraxEAQCws5gpBgBg9NxoBwDA6LnRDgCA0dM+AQDA6CmKAQAYPUUxAACjpygGAGD05rpOcVWtJFlZXl6eZxhbyprFAACLz+oTAACMnifabSOzxgAAi0lRvIG1BSwAALubG+0AABg9M8ULTLsFAMD2UBSvsZ0tEwpeAIDFsSVFcVW9Mcnrkrwoye3d/emtOM9usdkCeaPiXXENAHBxpi6Kq+p4ktcnebq7X7Zm/HCS9yTZk+QD3X1bd38iySeq6oVJ/jiJonhKGxW8bvwDANg6m5kpviPJnyX58HMDVbUnye1JfiLJapJTVXVPd39+8pHfm/ycbaAlAwDg4kxdFHf3fVV1YN3wtUnOdPdjSVJVdyW5sapOJ7ktyae6+7MzipVNUCADAExvaE/xviRPrNleTXJdkl9P8tokS1W13N3vX79jVR1NcjRJ9u/fPzAMLkSBDABwYUOL4jrPWHf3e5O890I7dvexqnoqycrevXtfNTAOpqRABgD4TkOL4tUkV67ZviLJk9Pu3N0nkpw4dOjQWwfGwUCKZQBgzIYWxaeSXF1VVyX5YpKbkrx52p2raiXJyvLy8sAwmKX1K10okgGA3W4zS7LdmeT6JJdV1WqSd3X3B6vqliT35tySbMe7+5Fpj2mmeL4s8wYAcM5mVp84ssH4ySQnL+bkZooBAFgE3zPPk3f3ie4+urS0NM8wAAAYubkWxVW1UlXHzp49O88wAAAYuaE32g2ip3jnsUoFALAbzbUoZmdwQx4AsNvNtSh2o93OttGs8UZFtJllAGBRaZ9g7rRkAADzpn2CudCSAQAskrmuPgEAAItATzEzMauZX60UAMA8eHgHAACjp30CAIDRc6Md22YRbq7TngEAnI+eYnYEax8DAFvJOsXseoswQw0ALDbtE4yWVgoA4DmKYhbWkBles8MAwGYoitnRFL8AwCxYkg0AgNGz+gTMmJUyAGDnsfoEzIGb/ABgsWifAABg9BTFAACMntUnYAa2ehUM7RYAsLUUxZDpik7LvwHA7qUohnXMygLA+My8KK6qlyb53SRL3f1zsz4+7FRmmgFgcU1VFFfV8SSvT/J0d79szfjhJO9JsifJB7r7tu5+LMnNVfXRrQgYttMiFrJmsgFg9qZdfeKOJIfXDlTVniS3J7khycEkR6rq4EyjAwCAbTDVTHF331dVB9YNX5vkzGRmOFV1V5Ibk3x+lgHCWC3iLDUA7FZDeor3JXlizfZqkuuq6geT/H6SV1TVO7v7D863c1UdTXI0Sfbv3z8gDNjZhrRDzGtfANhthhTFdZ6x7u7/SvK277Zzdx9LcixJDh061APiAACAQYYUxatJrlyzfUWSJzdzgKpaSbKyvLw8IAxgWovYkmHGGoBFMKQoPpXk6qq6KskXk9yU5M0ziQqYG0UqAGM01eoTVXVnkvuTXFNVq1V1c3c/m+SWJPcmOZ3k7u5+ZDMn7+4T3X10aWlps3EDAMDMTLv6xJENxk8mOXmxJ9c+AbNjhhcALt606xRvCTPFAAAsgrkWxQAAsAiG3Gg3mPYJ2HrTrDgxZFWK9ftu1LqhvQOARaZ9AgCA0dM+AQDA6GmfgAWyaA/X2A0tD5v9DrvhOwOwedonAAAYPe0TAACMnvYJYCrb3Vaw0fk2ajGZ5jPTHH9Wn58lLR0AW0/7BAAAo6d9AgCA0VMUAwAwenqKYRdatKXdhprX9xnyNMD1vb9b3Res7xhgGD3FAACMnvYJAABGT1EMAMDoKYoBABg9RTEAAKOnKAYAYPQsyQZs2oWWKhuyNNiQpdeGLJ+2KOfazqXndsMSbtv5HXbD3xdwYZZkAwBg9LRPAAAweopiAABGT1EMAMDoKYoBABg9RTEAAKM38yXZqurSJH+e5GtJPtPdH5n1OQAAYJammimuquNV9XRVPbxu/HBVPVpVZ6rq1snwm5J8tLvfmuQNM44XAABmbtr2iTuSHF47UFV7ktye5IYkB5McqaqDSa5I8sTkY1+fTZgAALB1pmqf6O77qurAuuFrk5zp7seSpKruSnJjktWcK4wfygWK7qo6muRokuzfv3+zcQM7wEZPaNvOJ7ctou18ct/ap69Nk4+NntY2zTE3u++FbPY7LJohf1879dwb5WbouTxNcGfYqv8LttOQG+325Vszwsm5Ynhfko8l+dmqel+SExvt3N3HuvtQdx+6/PLLB4QBAADDDLnRrs4z1t39P0l+daoDVK0kWVleXh4QBgAADDNkpng1yZVrtq9I8uRmDtDdJ7r76NLS0oAwAABgmCFF8akkV1fVVVW1N8lNSe7ZzAGqaqWqjp09e3ZAGAAAMMy0S7LdmeT+JNdU1WpV3dzdzya5Jcm9SU4nubu7H9nMyc0UAwCwCKZdfeLIBuMnk5y82JPrKQYAYBHM9THPZooBAFgE1d3zjiFV9UySL8zh1Jcl+fIczstwcrczydvOJXc7k7ztXHK3dX6ou79jPeCFKIrnpaoe6O5D846DzZO7nUnedi6525nkbeeSu+031/YJAABYBIpiAABGb+xF8bF5B8BFk7udSd52LrnbmeRt55K7bTbqnmIAAEjMFAMAwHiL4qo6XFWPVtWZqrp13vHw7arq8ar6XFU9VFUPTMZ+oKr+tqr+bfLnC9d8/p2TXD5aVT81v8jHp6qOV9XTVfXwmrFN56qqXjXJ+Zmqem9V1XZ/lzHZIG/vrqovTq67h6rqp9f8TN4WQFVdWVV/X1Wnq+qRqvqNybhrbsFdIHeuu0XR3aN7JdmT5N+TvDTJ3iT/nOTgvOPy+rYcPZ7ksnVjf5Tk1sn7W5P84eT9wUkOn5fkqklu98z7O4zlleQ1SV6Z5OEhuUryT0l+LEkl+VSSG+b93Xbza4O8vTvJb53ns/K2IK8kL0nyysn7FyT510l+XHML/rpA7lx3C/Ia60zxtUnOdPdj3f21JHcluXHOMfHd3ZjkQ5P3H0ryxjXjd3X3/3X3fyQ5k3M5Zht0931JvrJueFO5qqqXJPn+7r6/z/2P/+E1+7AFNsjbRuRtQXT3U9392cn7ryY5nWRfXHML7wK524jcbbOxFsX7kjyxZns1F/6HyfbrJJ+uqger6uhk7MXd/VRy7j+XJC+ajMvn4tlsrvZN3q8fZ/vdUlX/MmmveO5X8PK2gKrqQJJXJPnHuOZ2lHW5S1x3C2GsRfH5em8sw7FYXt3dr0xyQ5J3VNVrLvBZ+dw5NsqVHC6G9yX54SQvT/JUkj+ZjMvbgqmq5yf5qyS/2d3/faGPnmdM7uboPLlz3S2IsRbFq0muXLN9RZIn5xQL59HdT07+fDrJx3OuHeJLk18bZfLn05OPy+fi2WyuVifv14+zjbr7S9399e7+RpK/yLfakORtgVTV9+ZcUfWR7v7YZNg1twOcL3euu8Ux1qL4VJKrq+qqqtqb5KYk98w5Jiaq6tKqesFz75P8ZJKHcy5Hb5l87C1J/nry/p4kN1XV86rqqiRX59xNCMzPpnI1+XXvV6vqRyd3Uf/ymn3YJs8VVRM/k3PXXSJvC2Py9/zBJKe7+0/X/Mg1t+A2yp3rbnFcMu8A5qG7n62qW5Lcm3MrURzv7kfmHBbf8uIkH5+sMHNJkr/s7r+pqlNJ7q6qm5P8Z5KfT5LufqSq7k7y+STPJnlHd399PqGPT1XdmeT6JJdV1WqSdyW5LZvP1duT3JHk+3LubupPbePXGJ0N8nZ9Vb08534V+3iSX0vkbcG8OskvJflcVT00GfuduOZ2go1yd8R1txg80Q4AgNEba/sEAAB8k6IYAIDRUxQDADB6imIAAEZPUQwAwOgpigEAGD1FMQAAo6coBgBg9P4fr1RiIeHhWngAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -665,12 +756,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQNklEQVR4nO3db4xld1kH8O9jcTEBnAithmy77uI2jftKYFP8F0IiwS04FJFoFxPBNGxQa/SFiUswkZdgoi+IFbKEpmhIS0XUblhSDUoakwbakgItTWWpkA5tKEiyEmPEwuOLuS3XcWd7Z8+dvffO+XySk733N/ee88w+c2af/d3n/E51dwAAYMx+YNEBAADAoimKAQAYPUUxAACjpygGAGD0FMUAAIyeohgAgNF7zqIDSJLLL7+8Dx48uOgwAADY4+6///5vdvcVW8eXoig+ePBg7rvvvkWHAQDAHldVXz3fuPYJAABGT1EMAMDoLbQorqr1qjp17ty5RYYBAMDILbQo7u7T3X1ibW1tkWEAADBy2icAABi9pVh9YlEOnvz4/3n+lXe/bkGRAACwSGaKAQAYPUUxAACjpygGAGD0dqUorqrnVdX9VfVLu7F/AACYp5mK4qq6paqerKoHt4wfq6pHqupsVZ2c+tIfJrljnoECAMBumXWm+NYkx6YHquqyJDcnuS7JkSTHq+pIVb06yReTfH2OcQIAwK6ZaUm27r67qg5uGb42ydnufjRJqur2JNcneX6S52WzUP6vqjrT3d+bW8QAADBnQ9Yp3p/ksannG0le0d03JUlVvTXJN7criKvqRJITSXLgwIEBYQAAwDBDiuI6z1g/86D71gu9ubtPVdUTSdb37dv38gFxAADAIENWn9hIctXU8yuTPL6THXT36e4+sba2NiAMAAAYZkhRfG+Sq6vqUFXtS3JDkjt3soOqWq+qU+fOnRsQBgAADDPrkmy3JbknyTVVtVFVN3b3U0luSnJXkoeT3NHdD+3k4GaKAQBYBrOuPnF8m/EzSc5c7MGraj3J+uHDhy92FwAAMNhCb/NsphgAgGWw0KIYAACWwUKLYhfaAQCwDLRPAAAwemaKAQAYPTPFAACMngvtAAAYPUUxAACjp6cYAIDR01MMAMDoaZ8AAGD0FMUAAIyenmIAAEZPTzEAAKOnfQIAgNFTFAMAMHqKYgAARk9RDADA6Fl9AgCA0bP6BAAAo6d9AgCA0VMUAwAweopiAABGT1EMAMDoKYoBABi9uRfFVfWTVfX+qvpoVf3WvPcPAADzNlNRXFW3VNWTVfXglvFjVfVIVZ2tqpNJ0t0Pd/fbk/xqkqPzDxkAAOZr1pniW5Mcmx6oqsuS3JzkuiRHkhyvqiOTr70+yb8k+eTcIr0EDp78+DMbAADjMVNR3N13J/nWluFrk5zt7ke7+ztJbk9y/eT1d3b3zyb59XkGCwAAu+E5A967P8ljU883kryiql6V5I1JnpvkzHZvrqoTSU4kyYEDBwaEAQAAwwwpius8Y93dn0ryqWd7c3efqqonkqzv27fv5QPiAACAQYasPrGR5Kqp51cmeXwnO+ju0919Ym1tbUAYAAAwzJCi+N4kV1fVoaral+SGJHfuZAdVtV5Vp86dOzcgDAAAGGbWJdluS3JPkmuqaqOqbuzup5LclOSuJA8nuaO7H9rJwc0UAwCwDGbqKe7u49uMn8kFLqZ7NlW1nmT98OHDF7sLAAAYbKG3eTZTDADAMlhoUQwAAMtgoUWxC+0AAFgG2icAABi9ITfvGGyZL7Q7ePLjzzz+yrtft8BIAADYbWaKAQAYPRfaAQAweopiAABGz+oTAACMnp5iAABGT/sEAACjpygGAGD09BQDADB6eooBABi9hd7RblW4ux0AwN6mpxgAgNFTFAMAMHqKYgAARs/qEwAAjJ7VJwAAGD3tEwAAjJ6iGACA0VMUAwAweopiAABGzx3tdsjd7QAA9p5dmSmuqjdU1Qeq6u+r6jW7cQwAAJiXmYviqrqlqp6sqge3jB+rqkeq6mxVnUyS7v677n5bkrcm+bW5RgwAAHO2k5niW5Mcmx6oqsuS3JzkuiRHkhyvqiNTL/mjydcBAGBpzVwUd/fdSb61ZfjaJGe7+9Hu/k6S25NcX5vek+QT3f3Z+YULAADzN7SneH+Sx6aeb0zGfjfJq5O8qarefr43VtWJqrqvqu77xje+MTAMAAC4eENXn6jzjHV3vzfJey/0xu4+leRUkhw9erQHxgEAABdtaFG8keSqqedXJnl81jdX1XqS9cOHDw8MA8bDsoAAMH9Di+J7k1xdVYeSfC3JDUnePDgqWAGKUwDYO2YuiqvqtiSvSnJ5VW0k+ePu/mBV3ZTkriSXJbmlux+adZ/dfTrJ6aNHj75tZ2HD7pkudqfNWvhuVywPKaK3iwkAmI+Zi+LuPr7N+JkkZ+YW0QoxU8jTFK0AsNoWeptnPcWskktR+O70P1r+YwYA87HQolj7BMyv2J6lQFZEA8D5mSmGBZilEN6NYnm78SFF9Nb9K7YBWEVmihmVoRfRzet4u203jmuWGYC9bOgd7QAAYOVpn2DPsOTZpXOhv6/dWJIOAHab9gn2JEXuzvj7AmDsFloU7yVmwWB2zhcAls1Ce4qrar2qTp07d26RYQAAMHLaJ1hpPvZfbjvNjxlkABbF6hMAAIyenmJgKe32rLFZaQCmWZINWHqX+qYrAIyPnmJWjj7ivWVIPs32AjAv2idYWgoeAOBSURSzVMwCMw+z3FVvXvsEYG+w+gQAAKNnphhgihlhgHEyUwwAwOhZkm0XmGmCS29e/cIAjNNCZ4q7+3R3n1hbW1tkGAAAjJyeYmBP241ZYJ8GAew9imIumSGFhI+3WYRZfu4UyAB7gwvtAAAYPUUxAACjp30CYBdsbb3QWgGw3OZeFFfVS5K8M8lad79p3vtfNfoNn51+YcbG7wWA5TNT+0RV3VJVT1bVg1vGj1XVI1V1tqpOJkl3P9rdN+5GsAAAsBtm7Sm+Ncmx6YGquizJzUmuS3IkyfGqOjLX6AAA4BKYqX2iu++uqoNbhq9Ncra7H02Sqro9yfVJvjjLPqvqRJITSXLgwIEZw2XVbNcaoWWCsfEzD7Dchqw+sT/JY1PPN5Lsr6oXVdX7k7y0qt6x3Zu7+1R3H+3uo1dcccWAMAAAYJghF9rVeca6u/89ydtn2kHVepL1w4cPDwgDYG+Y1wV4LuQD2LkhM8UbSa6aen5lksd3soPuPt3dJ9bW1gaEAQAAwwyZKb43ydVVdSjJ15LckOTNO9mBmWKAZ2fmF2D3zbok221J7klyTVVtVNWN3f1UkpuS3JXk4SR3dPdDOzm4mWIAAJbBrKtPHN9m/EySMxd78DHPFO/lmR9X2cPsnC8Ay2FIT/FgZooBAFgGc7/N806MeaYY4ELMIANcWmaKAQAYvYUWxQAAsAy0T1xCPg6Fvc05DrC6tE8AADB62icAABg97RMAK2S7Fo3t1jvf6esBxkr7BAAAo6d9AgCA0VMUAwAweopiAABGz4V2XLTpC3hctAMArDIX2gEAMHraJwAAGD1FMQAAo6coBgBg9BTFAACMntUnVtClXvXBKhOw/La7nfNO37vTc3yW20j7HQKsAqtPAAAwetonAAAYPUUxAACjpygGAGD0FMUAAIyeohgAgNGb+5JsVfW8JH+R5DtJPtXdH573MQAAYJ5mmimuqluq6smqenDL+LGqeqSqzlbVycnwG5N8tLvfluT1c44XAADmbtb2iVuTHJseqKrLktyc5LokR5Icr6ojSa5M8tjkZd+dT5gAALB7Zmqf6O67q+rgluFrk5zt7keTpKpuT3J9ko1sFsYP5AJFd1WdSHIiSQ4cOLDTuPesRd35aehxh9xNC7j0tjtn53Uuz7r/We58dyl/L85yh76d7meV7uJ3KXMwy7HmebyxWOafvWWOLRl2od3+fH9GONkshvcn+ViSX6mq9yU5vd2bu/tUdx/t7qNXXHHFgDAAAGCYIRfa1XnGurv/M8lvzrSDqvUk64cPHx4QBgAADDNkpngjyVVTz69M8vhOdtDdp7v7xNra2oAwAABgmCFF8b1Jrq6qQ1W1L8kNSe7cyQ6qar2qTp07d25AGAAAMMysS7LdluSeJNdU1UZV3djdTyW5KcldSR5Ockd3P7STg5spBgBgGcy6+sTxbcbPJDlzsQfXUwwAwDJY6G2ezRQDALAMqrsXHUOq6htJvrqAQ1+e5JsLOC4XR75Wh1ytDrlaHXK1OuRquf14d/+/9YCXoihelKq6r7uPLjoOZiNfq0OuVodcrQ65Wh1ytZoW2j4BAADLQFEMAMDojb0oPrXoANgR+VodcrU65Gp1yNXqkKsVNOqeYgAASMwUAwDAeIviqjpWVY9U1dmqOrnoeMaqqr5SVV+oqgeq6r7J2Aur6h+r6kuTP39k6vXvmOTskar6xanxl0/2c7aq3ltVtYjvZy+pqluq6smqenBqbG65qarnVtVHJuOfrqqDl/L720u2ydW7quprk3Prgap67dTX5GoBquqqqvrnqnq4qh6qqt+bjDuvltAF8uXc2qu6e3RbksuSfDnJS5LsS/K5JEcWHdcYtyRfSXL5lrE/SXJy8vhkkvdMHh+Z5Oq5SQ5NcnjZ5GufSfIzSSrJJ5Jct+jvbdW3JK9M8rIkD+5GbpL8dpL3Tx7fkOQji/6eV3XbJlfvSvIH53mtXC0uTy9O8rLJ4xck+ddJPpxXS7hdIF/OrT26jXWm+NokZ7v70e7+TpLbk1y/4Jj4vuuTfGjy+ENJ3jA1fnt3/3d3/1uSs0muraoXJ/nh7r6nN3+z/OXUe7hI3X13km9tGZ5nbqb39dEkv2CG/+Jsk6vtyNWCdPcT3f3ZyeNvJ3k4yf44r5bSBfK1HflacWMtivcneWzq+UYu/IPO7ukk/1BV91fVicnYj3X3E8nmL6UkPzoZ3y5v+yePt44zf/PMzTPv6e6nkpxL8qJdi3ycbqqqz0/aK57+SF6ulsDkY/KXJvl0nFdLb0u+EufWnjTWovh8/wuzDMdi/Fx3vyzJdUl+p6peeYHXbpc3+Vy8i8mNvO2u9yX5iSQ/leSJJH86GZerBauq5yf5myS/393/caGXnmdMri6x8+TLubVHjbUo3khy1dTzK5M8vqBYRq27H5/8+WSSv81ma8vXJx83ZfLnk5OXb5e3jcnjrePM3zxz88x7quo5SdYyewsAz6K7v97d3+3u7yX5QDbPrUSuFqqqfjCbBdaHu/tjk2Hn1ZI6X76cW3vXWIvie5NcXVWHqmpfNpvb71xwTKNTVc+rqhc8/TjJa5I8mM1cvGXysrck+fvJ4zuT3DC5WvdQkquTfGbyceO3q+qnJ71YvzH1HuZrnrmZ3tebkvzTpN+OOXi6yJr45WyeW4lcLczk7/WDSR7u7j+b+pLzagltly/n1h626Cv9FrUleW02ryT9cpJ3LjqeMW7ZXP3jc5PtoafzkM1+qk8m+dLkzxdOveedk5w9kqkVJpIczeYvpi8n+fNMbkxjG5Sf27L50eD/ZHM248Z55ibJDyX562xejPKZJC9Z9Pe8qts2ufqrJF9I8vls/sP7YrlaeJ5+PpsfjX8+yQOT7bXOq+XcLpAv59Ye3dzRDgCA0Rtr+wQAADxDUQwAwOgpigEAGD1FMQAAo6coBgBg9BTFAACMnqIYAIDRUxQDADB6/wv9LjleSVjbWQAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQMklEQVR4nO3db4xld1kH8O/D4mJScCK0GLLtusVtGveVwKb4L4RE1C24FJFoFxPBNGxQa/SFiUswkZdgoi8IFbKGpmBIS0XUblhSDEoakwbakgJbNpWllnRowxZJVmKMtfD4Ym7LOO5s7+y5s/feOZ9PcrP3/uaec56ZZ8706e8+53equwMAAGP2vHkHAAAA86YoBgBg9BTFAACMnqIYAIDRUxQDADB6imIAAEbv+fMOIEkuv/zy3rdv37zDAABgh3vggQe+3d1XbBxfiKJ43759uf/+++cdBgAAO1xVfeN849onAAAYPUUxAACjN9eiuKoOV9Xxc+fOzTMMAABGbq5FcXef6O6jKysr8wwDAICR0z4BAMDoLcTqE/Oy79in/s/rR9/7hjlFAgDAPJkpBgBg9BTFAACMnqIYAIDR25aiuKouq6oHqupXtmP/AAAwS1MVxVV1a1WdrapTG8YPVdXDVXWmqo6t+9IfJ7lzloECAMB2mXam+LYkh9YPVNWuJLckuT7JgSRHqupAVb0uyVeTfGuGcQIAwLaZakm27r6nqvZtGL4uyZnufiRJquqOJDckeWGSy7JWKP9XVZ3s7u9v3GdVHU1yNEn27t17sfEDAMBgQ9Yp3pPksXWvV5O8urtvTpKqenuSb5+vIE6S7j6e5HiSHDx4sAfEAQAAgwwpius8Y88Wt91923PuoOpwksP79+8fEAYAAAwzZPWJ1SRXrXt9ZZLHt7KD7j7R3UdXVlYGhAEAAMMMKYrvS3JNVV1dVbuT3Jjkrq3soKoOV9Xxc+fODQgDAACGmXZJttuT3Jvk2qparaqbuvvpJDcnuTvJ6SR3dvdDWzm4mWIAABbBtKtPHNlk/GSSkxd7cD3FAAAsgrne5tlMMQAAi2CuRbGeYgAAFoGZYgAARm+uRTEAACwC7RMAAIye9gkAAEZP+wQAAKOnfQIAgNHTPgEAwOhpnwAAYPQUxQAAjJ6iGACA0XOhHQAAo+dCOwAARk/7BAAAo6coBgBg9BTFAACMnqIYAIDRs/oEAACjZ/UJAABGT/sEAACjpygGAGD0FMUAAIyeohgAgNFTFAMAMHozL4qr6ier6kNV9Ymq+p1Z7x8AAGZtqqK4qm6tqrNVdWrD+KGqeriqzlTVsSTp7tPd/c4kv57k4OxDBgCA2Zp2pvi2JIfWD1TVriS3JLk+yYEkR6rqwORrb0zyL0k+O7NIL4F9xz717AMAgPGYqiju7nuSfGfD8HVJznT3I939VJI7ktwwef9d3f2zSX5zlsECAMB2eP6AbfckeWzd69Ukr66q1yZ5c5IXJDm52cZVdTTJ0STZu3fvgDAAAGCYIUVxnWesu/tzST73XBt39/GqeiLJ4d27d79qQBwAADDIkNUnVpNcte71lUke38oOuvtEdx9dWVkZEAYAAAwzpCi+L8k1VXV1Ve1OcmOSu7ayg6o6XFXHz507NyAMAAAYZtol2W5Pcm+Sa6tqtapu6u6nk9yc5O4kp5Pc2d0PbeXgZooBAFgEU/UUd/eRTcZP5gIX0z2Xqjqc5PD+/fsvdhcAADDYXG/zbKYYAIBFMNeiGAAAFsFci2IX2gEAsAi0TwAAMHpDbt4x2CJfaLfv2Keeff7oe98wx0gAANhuZooBABg9F9oBADB6imIAAEbP6hMAAIyenmIAAEZP+wQAAKOnKAYAYPT0FAMAMHp6igEAGD3tEwAAjN5cb/O8LNzyGQBgZzNTDADA6CmKAQAYPatPAAAwelafAABg9LRPAAAweopiAABGT1EMAMDoKYoBABg9RTEAAKO3LXe0q6o3JXlDkpcmuaW7P7Mdx5kHd7cDANh5pp4prqpbq+psVZ3aMH6oqh6uqjNVdSxJuvvvu/sdSd6e5DdmGjEAAMzYVtonbktyaP1AVe1KckuS65McSHKkqg6se8ufTL4OAAALa+qiuLvvSfKdDcPXJTnT3Y9091NJ7khyQ615X5JPd/cXZxcuAADM3tAL7fYkeWzd69XJ2O8neV2St1TVO8+3YVUdrar7q+r+J598cmAYAABw8YZeaFfnGevufn+S919ow+4+nuR4khw8eLAHxgEAABdtaFG8muSqda+vTPL4tBtX1eEkh/fv3z8wDLj0rEQCADvH0KL4viTXVNXVSb6Z5MYkbx0cFbApxTgAzN7URXFV3Z7ktUkur6rVJH/a3R+uqpuT3J1kV5Jbu/uhaffZ3SeSnDh48OA7thY2XBoXU4Buts2QYnb9tgDA7E1dFHf3kU3GTyY5eTEH1z7BTqFoBYDlti13tJvWss8U+xh7Z9qswF3EwtfvIADMxlyLYmDzYntIi8Vm287qWACw08y1KNY+Adtvu2e4N+5fgQ3AMtI+wahc6pnSIa0YQ4rZWRXC2jMAGAvtE8BUFMgA7GTaJ9gxLHl28bb6s7vQz2s7lqQDgO2mfYIdaexF7hCX4menQAZg0WifmBH/kQcAWF7Pm+fBq+pwVR0/d+7cPMMAAGDktE8A20YbCwDLQvsES03RtbNoQwJgXhTFwELa7gJZAQ7AepZkAxae21MDsN30FLN0tEzsLLO6c58CGYAhtE+wsBQ8AMCloihmoZgFZhamuaverPYJwM6gKAZYR/ELME5zvXkHAAAsAkUxAACjZ0m2beDjV7j09KMDMIQl2YDRU1AD4EI7YEfbjoLXp0EAO4+imEtmSCFhJo95mOb3ToEMsDO40A4AgNFTFAMAMHraJwC2wcbWC60VAItt5kVxVb08ybuTrHT3W2a9f3Ye/cKMjT5kgMUzVftEVd1aVWer6tSG8UNV9XBVnamqY0nS3Y90903bESwAAGyHaWeKb0vygSQffWagqnYluSXJLyZZTXJfVd3V3V+ddZDLzIwQAMDim6oo7u57qmrfhuHrkpzp7keSpKruSHJDkqmK4qo6muRokuzdu3fKcFk2m7VGaJlgbPzOAyy2IatP7Eny2LrXq0n2VNVLqupDSV5RVe/abOPuPt7dB7v74BVXXDEgDAAAGGbIhXZ1nrHu7n9P8s6pdlB1OMnh/fv3DwgDYGeYVbuVti2ArRsyU7ya5Kp1r69M8vhWdtDdJ7r76MrKyoAwAABgmCEzxfcluaaqrk7yzSQ3JnnrVnZgphjguZn5Bdh+0y7JdnuSe5NcW1WrVXVTdz+d5OYkdyc5neTO7n5oKwc3UwwAwCKYdvWJI5uMn0xy8mIPbqZ4Z3KVPUzP+QKwGIb0FA9mphgAgEUw89s8b8WYZ4r1CAIXYgYZ4NIyUwwAwOjNtSgGAIBFoH3iEvJxKOxsznGA5aV9AgCA0dM+AQDA6GmfAFgim7VobLaKzVbfDzBW2icAABg97RMAAIyeohgAgNFTFAMAMHoutOOiuVU1ALBTuNAOAIDR0z4BAMDoKYoBABg9RTEAAKOnKAYAYPSsPrGELvWqD1aZgMW32e2ct7rtVs/xaW4j7W8IsAysPgEAwOhpnwAAYPQUxQAAjJ6iGACA0VMUAwAweopiAABGb+ZLslXVZUn+MslTST7X3R+b9TEAAGCWppoprqpbq+psVZ3aMH6oqh6uqjNVdWwy/OYkn+judyR544zjBQCAmZu2feK2JIfWD1TVriS3JLk+yYEkR6rqQJIrkzw2edv3ZhMmAABsn6naJ7r7nqrat2H4uiRnuvuRJKmqO5LckGQ1a4Xxg7lA0V1VR5McTZK9e/duNe4da153fhp63CF30wIuvc3O2Vmdy9Puf5o7313Kv4vT3KFvq/tZprv4XcocTHOsWR5vLBb5d2+RY0uGXWi3Jz+YEU7WiuE9ST6Z5Neq6oNJTmy2cXcf7+6D3X3wiiuuGBAGAAAMM+RCuzrPWHf3fyb57al2UHU4yeH9+/cPCAMAAIYZMlO8muSqda+vTPL4VnbQ3Se6++jKysqAMAAAYJghRfF9Sa6pqquraneSG5PctZUdVNXhqjp+7ty5AWEAAMAw0y7JdnuSe5NcW1WrVXVTdz+d5OYkdyc5neTO7n5oKwc3UwwAwCKYdvWJI5uMn0xy8mIPrqcYAIBFMNfbPJspBgBgEVR3zzuGVNWTSb4xh0NfnuTbczguF0e+lodcLQ+5Wh5ytTzkarH9eHf/v/WAF6Ionpequr+7D847DqYjX8tDrpaHXC0PuVoecrWc5to+AQAAi0BRDADA6I29KD4+7wDYEvlaHnK1PORqecjV8pCrJTTqnmIAAEjMFAMAwHiL4qo6VFUPV9WZqjo273jGqqoeraqvVNWDVXX/ZOzFVfWPVfW1yb8/uu7975rk7OGq+uV146+a7OdMVb2/qmoe389OUlW3VtXZqjq1bmxmuamqF1TVxyfjn6+qfZfy+9tJNsnVe6rqm5Nz68Gqev26r8nVHFTVVVX1z1V1uqoeqqo/mIw7rxbQBfLl3Nqpunt0jyS7knw9ycuT7E7ypSQH5h3XGB9JHk1y+YaxP0tybPL8WJL3TZ4fmOTqBUmunuRw1+RrX0jyM0kqyaeTXD/v723ZH0lek+SVSU5tR26S/G6SD02e35jk4/P+npf1sUmu3pPkj87zXrmaX55eluSVk+cvSvKvk3w4rxbwcYF8Obd26GOsM8XXJTnT3Y9091NJ7khyw5xj4gduSPKRyfOPJHnTuvE7uvu/u/vfkpxJcl1VvSzJj3T3vb32l+Wj67bhInX3PUm+s2F4lrlZv69PJPkFM/wXZ5NcbUau5qS7n+juL06efzfJ6SR74rxaSBfI12bka8mNtSjek+Sxda9Xc+FfdLZPJ/lMVT1QVUcnYz/W3U8ka3+Ukrx0Mr5Z3vZMnm8cZ/ZmmZtnt+nup5OcS/KSbYt8nG6uqi9P2iue+UherhbA5GPyVyT5fJxXC29DvhLn1o401qL4fP8XZhmO+fi57n5lkuuT/F5VveYC790sb/I5fxeTG3nbXh9M8hNJfirJE0n+fDIuV3NWVS9M8rdJ/rC7/+NCbz3PmFxdYufJl3NrhxprUbya5Kp1r69M8vicYhm17n588u/ZJH+XtdaWb00+bsrk37OTt2+Wt9XJ843jzN4sc/PsNlX1/CQrmb4FgOfQ3d/q7u919/eT/FXWzq1Eruaqqn4oawXWx7r7k5Nh59WCOl++nFs711iL4vuSXFNVV1fV7qw1t98155hGp6ouq6oXPfM8yS8lOZW1XLxt8ra3JfmHyfO7ktw4uVr36iTXJPnC5OPG71bVT096sX5r3TbM1ixzs35fb0nyT5N+O2bgmSJr4lezdm4lcjU3k5/rh5Oc7u6/WPcl59UC2ixfzq0dbN5X+s3rkeT1WbuS9OtJ3j3veMb4yNrqH1+aPB56Jg9Z66f6bJKvTf598bpt3j3J2cNZt8JEkoNZ+8P09SQfyOTGNB6D8nN71j4a/J+szWbcNMvcJPnhJH+TtYtRvpDk5fP+npf1sUmu/jrJV5J8OWv/4X2ZXM09Tz+ftY/Gv5zkwcnj9c6rxXxcIF/OrR36cEc7AABGb6ztEwAA8CxFMQAAo6coBgBg9BTFAACMnqIYAIDRUxQDADB6imIAAEZPUQwAwOj9LwWjQs8sbeMxAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -692,12 +783,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAO+klEQVR4nO3dX6zkZ1kH8O9jazFBPBG6GrIttnUb4l4JntS/ISQqbiFLEYm2mIim6Qa1Ri+8WIKJXIKJXhAqZAlNwZAWRJRuWFINShqTBrolBVqbylJLupTQxSYr8cJafLw403I47Fnm7MzZmTnv55P8cmbe+f155zz9nT77zvO+U90dAAAY2Q8sugMAALBokmIAAIYnKQYAYHiSYgAAhicpBgBgeJJiAACGd+miO5Akl19+eV911VWL7gYAAHvcAw888M3u3re1faFJcVUdTnL4wIEDOXny5CK7AgDAAKrqq+dqX2j5RHcf7+4ja2tri+wGAACDW2hSXFWHq+rY2bNnF9kNAAAGZ6QYAIDhWX0CAIDhKZ8AAGB4C119oruPJzm+vr5+yyKuf9XRT37X88ff+bpFdAMAgAUzUgwAwPBMtAMAYHgm2gEAMDzlEwAADE/5BAAAw1M+AQDA8CTFAAAMT00xAADDU1MMAMDwlE8AADA8STEAAMOTFAMAMDwT7QAAGJ6JdgAADE/5BAAAw5MUAwAwPEkxAADDkxQDADA8STEAAMOzJBsAAMOzJBsAAMNTPgEAwPAkxQAADE9SDADA8CTFAAAMT1IMAMDwJMUAAAxv7klxVf1UVb2vqj5WVb8/7/MDAMC8TZUUV9XtVfVUVT20pf1QVT1aVaeq6miSdPcj3f3WJL+ZZH3+XQYAgPmadqT4jiSHNjdU1SVJbktyfZKDSW6qqoOT116f5F+TfHpuPQUAgF0yVVLc3fcmeXpL83VJTnX3Y939TJK7ktww2f/u7v6FJL+93Tmr6khVnayqk2fOnLmw3gMAwBxcOsOx+5M8sen56SQ/W1WvTvLGJC9IcmK7g7v7WJJjSbK+vt4z9AMAAGYyS1Jc52jr7v5Mks9MdYKqw0kOHzhwYIZuAADAbGZZfeJ0kis3Pb8iyZM7OUF3H+/uI2trazN0AwAAZjNLUnx/kmur6uqquizJjUnu3skJqupwVR07e/bsDN0AAIDZTLsk251J7kvy8qo6XVU3d/ezSW5Nck+SR5J8tLsf3snFjRQDALAMpqop7u6btmk/kfNMpgMAgFWw0K95Vj4BAMAyWGhSrHwCAIBlYKQYAIDhGSkGAGB4C02KAQBgGSifAABgeMonAAAYnvIJAACGJykGAGB4aooBABiemmIAAIanfAIAgOFJigEAGJ6kGACA4ZloBwDA8Ey0AwBgeMonAAAYnqQYAIDhSYoBABiepBgAgOFJigEAGJ4l2QAAGJ4l2QAAGJ7yCQAAhicpBgBgeJJiAACGJykGAGB4kmIAAIYnKQYAYHi7khRX1Ruq6v1V9Ymqes1uXAMAAOZl6qS4qm6vqqeq6qEt7Yeq6tGqOlVVR5Oku/+hu29J8rtJfmuuPQYAgDnbyUjxHUkObW6oqkuS3Jbk+iQHk9xUVQc37fJnk9cBAGBpTZ0Ud/e9SZ7e0nxdklPd/Vh3P5PkriQ31IZ3JflUd3/+XOerqiNVdbKqTp45c+ZC+w8AADObtaZ4f5InNj0/PWn7oyS/kuRNVfXWcx3Y3ce6e7271/ft2zdjNwAA4MJdOuPxdY627u53J3n39z246nCSwwcOHJixGwAAcOFmHSk+neTKTc+vSPLktAd39/HuPrK2tjZjNwAA4MLNOlJ8f5Jrq+rqJF9LcmOSN097sJFiVtlVRz/5/OPH3/m6Bfbkey1z3wBgGU2dFFfVnUleneTyqjqd5M+7+wNVdWuSe5JckuT27n542nN29/Ekx9fX12/ZWbdh9UyTqO40mZX8AsB8TJ0Ud/dN27SfSHLiQi5upBimI/kFgN01a/nETIwUs1fsxgjv5n1maZ+lD7PsDwCrZFe+5hkAAFbJQkeKlU+wSqYdid3piO1u241a5nleGwCWgfIJhrVdwnaxk9qLeb1ZSiy2a5fsArAXLDQphmWxbKO7AMDFtdCa4qo6XFXHzp49u8huAAAwOOUTwHeZtcTiYtctA8A8KJ9gKMokdp/fMQCryJJsAAAMz5JswEW3yGXiAOBc1BQDS0PpBQCLoqaYPWNZ1h1mZ+YVHyPLAMxCUsxKk/COQZwB2G0m2gEAMDwT7diTjCzynGnKapRbALDQkeLuPt7dR9bW1hbZDQAABqemGNhzfFIAwE5JioFhTJMsK6sAGJOkGGCH1CkD7D2SYmB4yi0AsCQbAADDsyQbK8eoHqtIaQXAcltoUtzdx5McX19fv2WR/QD4fnb6jzH/eANYLconAAAYnol2ANsw2gswDiPFAAAMz0gxwAyMJgPsDZJilpbZ+gDAxSIpZiUYjQMAdtPck+KquibJ25Osdfeb5n1+9gZJLgCwTKaaaFdVt1fVU1X10Jb2Q1X1aFWdqqqjSdLdj3X3zbvRWQAA2A3TjhTfkeQ9ST70XENVXZLktiS/muR0kvur6u7u/rd5dxJgL5mmXl5NPcDFNdVIcXffm+TpLc3XJTk1GRl+JsldSW6Y9sJVdaSqTlbVyTNnzkzdYQAAmLdZ1inen+SJTc9PJ9lfVS+pqvcleUVVvW27g7v7WHevd/f6vn37ZugGAADMZpaJdnWOtu7u/0zy1qlOUHU4yeEDBw7M0A0AAJjNLCPFp5Ncuen5FUme3MkJuvt4dx9ZW1uboRsAADCbWUaK709ybVVdneRrSW5M8uadnMBI8VgswwaLZfIewPamXZLtziT3JXl5VZ2uqpu7+9kktya5J8kjST7a3Q/v5OJGigEAWAZTjRR3903btJ9IcuJCL26kGBjdNJ+gbLeP0V6A+ZmlpnhmRooBAFgGC02KAQBgGcwy0W5myicA5mOWSXR7bQLeXns/wMWhfAIAgOEpnwAAYHjKJwD2MOuDA0xH+QQAAMNTPgEAwPAkxQAADE9NMXNnOSS4OJa5XtjfAWDVqCkGAGB4yicAABiepBgAgOFJigEAGJ6JdlwwE2lgOc1rAp57HBiJiXYAAAxP+QQAAMOTFAMAMDxJMQAAw5MUAwAwPEkxAADDsyQbwIC2W7Ztp+2bTbNs29bz7PQYS8MBu8WSbAAADE/5BAAAw5MUAwAwPEkxAADDkxQDADA8STEAAMOTFAMAMLy5r1NcVS9M8tdJnknyme7+8LyvAQAA8zTVSHFV3V5VT1XVQ1vaD1XVo1V1qqqOTprfmORj3X1LktfPub8AADB305ZP3JHk0OaGqrokyW1Jrk9yMMlNVXUwyRVJnpjs9u35dBMAAHbPVOUT3X1vVV21pfm6JKe6+7Ekqaq7ktyQ5HQ2EuMHc56ku6qOJDmSJC972ct22m+WzCxfDQvsbef7O7Dda7vxdc47/broeX219Sx9uNhm+R3tdsx26xq7Ydl+j8ti2d/nLBPt9uc7I8LJRjK8P8nHk/xGVb03yfHtDu7uY9293t3r+/btm6EbAAAwm1km2tU52rq7/zvJ7011gqrDSQ4fOHBghm4AAMBsZhkpPp3kyk3Pr0jy5E5O0N3Hu/vI2traDN0AAIDZzJIU35/k2qq6uqouS3Jjkrt3coKqOlxVx86ePTtDNwAAYDbTLsl2Z5L7kry8qk5X1c3d/WySW5Pck+SRJB/t7od3cnEjxQAALINpV5+4aZv2E0lOXOjF1RQDALAMFvo1z0aKAQBYBtXdi+5DqupMkq8u4NKXJ/nmAq7LfIjfahO/1SZ+q038Vpv4zeYnuvt71gNeiqR4UarqZHevL7ofXBjxW23it9rEb7WJ32oTv92x0PIJAABYBpJiAACGN3pSfGzRHWAm4rfaxG+1id9qE7/VJn67YOiaYgAASIwUAwDAuElxVR2qqker6lRVHV10f/iOqnq8qr5UVQ9W1clJ24ur6p+q6suTnz+6af+3TeL4aFX92qb2n5mc51RVvbuqahHvZ6+rqtur6qmqemhT29ziVVUvqKqPTNo/W1VXXcz3t9dtE793VNXXJvfgg1X12k2vid+SqKorq+pfquqRqnq4qv540u7+WwHniZ/7b1G6e7gtySVJvpLkmiSXJflCkoOL7pft+fg8nuTyLW1/keTo5PHRJO+aPD44id8Lklw9ieslk9c+l+Tnk1SSTyW5ftHvbS9uSV6V5JVJHtqNeCX5gyTvmzy+MclHFv2e99K2TfzekeRPz7Gv+C3RluSlSV45efyiJP8+iZH7bwW288TP/begbdSR4uuSnOrux7r7mSR3JblhwX3i/G5I8sHJ4w8mecOm9ru6+3+6+z+SnEpyXVW9NMmPdPd9vfHX4EObjmGOuvveJE9vaZ5nvDaf62NJftmo//xsE7/tiN8S6e6vd/fnJ4+/leSRJPvj/lsJ54nfdsRvl42aFO9P8sSm56dz/v8Qubg6yT9W1QNVdWTS9uPd/fVk4w9Jkh+btG8Xy/2Tx1vbuTjmGa/nj+nuZ5OcTfKSXes5z7m1qr44Ka947uN38VtSk4/FX5Hks3H/rZwt8UvcfwsxalJ8rn8lWYZjefxid78yyfVJ/rCqXnWefbeLpRgvpwuJl1hefO9N8pNJfjrJ15P85aRd/JZQVf1wkr9L8ifd/V/n2/UcbeK3YOeIn/tvQUZNik8nuXLT8yuSPLmgvrBFdz85+flUkr/PRrnLNyYfEWXy86nJ7tvF8vTk8dZ2Lo55xuv5Y6rq0iRrmf7jfi5Ad3+ju7/d3f+X5P3ZuAcT8Vs6VfWD2UioPtzdH580u/9WxLni5/5bnFGT4vuTXFtVV1fVZdkoPr97wX0iSVW9sKpe9NzjJK9J8lA24vOWyW5vSfKJyeO7k9w4mWF7dZJrk3xu8pHht6rq5yb1U7+z6Rh23zzjtflcb0ryz5O6OXbJcwnVxK9n4x5MxG+pTH7XH0jySHf/1aaX3H8rYLv4uf8WaNEz/Ra1JXltNmZ6fiXJ2xfdH9vzcbkmG7Nrv5Dk4edik40aqE8n+fLk54s3HfP2SRwfzaYVJpKsZ+OPyVeSvCeTL6uxzT1md2bjI77/zcaoxM3zjFeSH0ryt9mYVPK5JNcs+j3vpW2b+P1Nki8l+WI2/qf6UvFbvi3JL2Xjo/AvJnlwsr3W/bca23ni5/5b0OYb7QAAGN6o5RMAAPA8STEAAMOTFAMAMDxJMQAAw5MUAwAwPEkxAADDkxQDADA8STEAAMP7f2IV5F0QnUrUAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAO8UlEQVR4nO3dX6zkZ1kH8O9jazFBPBG6GrIttnUb4l4JntS/ISQqbiFLEYm2moim6Qa1Ri+8WIKJXIKJXhAqZAlNwZAWRJRuWFINShqTBrolBVqbylJLeiihi01W4oW1+HhxpuWw7tnO2ZmzM3Pezyf55cy88/vzznn6O332ned9p7o7AAAwsu9bdAcAAGDRJMUAAAxPUgwAwPAkxQAADE9SDADA8CTFAAAM79JFdyBJLr/88r7qqqsW3Q0AAPa4Bx544Fvdve/s9oUmxVV1OMnhAwcO5OTJk4vsCgAAA6iqr52rfaHlE919vLuPrK2tLbIbAAAMbqFJcVUdrqpjZ86cWWQ3AAAYnJFiAACGZ6QYAIDhGSkGAGB4S7Ek26JcdfRT3/P88Xe9YUE9AQBgkZRPAAAwPOUTAAAMz9c8AwAwPOUTAAAMT/kEAADDUz4BAMDwJMUAAAxPTTEAAMNTUwwAwPCUTwAAMDxJMQAAw5MUAwAwPBPtAAAYnol2AAAMT/kEAADDkxQDADA8STEAAMOTFAMAMDxJMQAAw7MkGwAAw7MkGwAAw1M+AQDA8CTFAAAMT1IMAMDwJMUAAAxPUgwAwPAkxQAADG/uSXFV/URVvb+qPl5Vvzfv8wMAwLxNlRRX1e1V9VRVPXRW+6GqerSqTlXV0STp7ke6+21Jfj3J+vy7DAAA8zXtSPEdSQ5tbaiqS5LcluT6JAeT3FRVByevvTHJvyT5zNx6CgAAu2SqpLi7703y9FnN1yU51d2PdfczSe5KcsNk/7u7++eS/NZ256yqI1V1sqpOnj59+sJ6DwAAc3DpDMfuT/LElucbSX66ql6b5M1JXpTkxHYHd/exJMeSZH19vWfoBwAAzGSWpLjO0dbd/dkkn53qBFWHkxw+cODADN0AAIDZzLL6xEaSK7c8vyLJkzs5QXcf7+4ja2trM3QDAABmM0tSfH+Sa6vq6qq6LMmNSe7eyQmq6nBVHTtz5swM3QAAgNlMuyTbnUnuS/LKqtqoqpu7+9kktya5J8kjST7W3Q/v5OJGigEAWAZT1RR3903btJ/IeSbTvRA1xQAALIOFfs2zkWIAAJbBQpNiAABYBgtNik20AwBgGSifAABgeMonAAAYnvIJAACGp3wCAIDhKZ8AAGB4kmIAAIanphgAgOGpKQYAYHjKJwAAGJ6kGACA4UmKAQAYnol2AAAMz0Q7AACGp3wCAIDhSYoBABiepBgAgOFJigEAGJ6kGACA4VmSDQCA4VmSDQCA4SmfAABgeJJiAACGJykGAGB4kmIAAIYnKQYAYHiSYgAAhrcrSXFVvamqPlBVn6yq1+3GNQAAYF6mToqr6vaqeqqqHjqr/VBVPVpVp6rqaJJ099939y1JfifJb8y1xwAAMGc7GSm+I8mhrQ1VdUmS25Jcn+Rgkpuq6uCWXf508joAACytqZPi7r43ydNnNV+X5FR3P9bdzyS5K8kNtendST7d3V841/mq6khVnayqk6dPn77Q/gMAwMxmrSnen+SJLc83Jm1/mOSXkrylqt52rgO7+1h3r3f3+r59+2bsBgAAXLhLZzy+ztHW3f2eJO95wYOrDic5fODAgRm7AQAAF27WkeKNJFdueX5FkienPbi7j3f3kbW1tRm7AQAAF27WpPj+JNdW1dVVdVmSG5PcPe3BVXW4qo6dOXNmxm4AAMCFm7p8oqruTPLaJJdX1UaSP+vuD1bVrUnuSXJJktu7++Fpz9ndx5McX19fv2Vn3YbVc9XRTz3/+PF3veGC95lm/52eBwBGN3VS3N03bdN+IsmJC7m4mmJWmcQTAPaOWSfazcRIMXvFbifIOx1lntc5Z9kfAFbJQpNiGNUsSe5Ok18A4IUtNClWPsFetyoJ7G6NAhtdBmBVKJ9gWLOUD8xjv4tllv5MM1ot2QVgL1A+AVlsIrtsSTQAjGjWdYpnYp1iAACWgfIJ4HvMsopFMr81mAHgYlroSDEAACwDNcUMRf3u7pvX79jIMgAXkyXZgItOwgvAslFTDCwNI/kALIryCfYMo4+rSbkFAMtAUsxKmyahMvq4+sQQgN1m9QkAAIZnoh17kpFFnrNdWYVyCwC2WuhIcXcf7+4ja2tri+wGAACDU1MM7Dk+KQBgpyTFwDB2OjFTWQXAOCTFADskcQbYeyTFwPCslQyAJdkAABieJdlYOSZRsYqMIgMst4Umxd19PMnx9fX1WxbZD4AXstN/jPnHG8BqUT4BAMDwTLQD2IbRXoBxSIoBZiBxBtgblE8AADA8I8UsLbP1AYCLRVLMSvARNQCwm+aeFFfVNUnekWStu98y7/OzN0hyAYBlMlVNcVXdXlVPVdVDZ7UfqqpHq+pUVR1Nku5+rLtv3o3OAgDAbph2pPiOJO9N8uHnGqrqkiS3JfnlJBtJ7q+qu7v7X+fdSYC9ZJp6eTX1ABfXVCPF3X1vkqfPar4uyanJyPAzSe5KcsO0F66qI1V1sqpOnj59euoOAwDAvM2yJNv+JE9seb6RZH9Vvayq3p/kVVX19u0O7u5j3b3e3ev79u2boRsAADCbWSba1Tnaurv/I8nbpjpB1eEkhw8cODBDNwAAYDazjBRvJLlyy/Mrkjy5kxN09/HuPrK2tjZDNwAAYDazjBTfn+Taqro6ydeT3JjkN3dyAiPFY7EMGyyWyXsA25t2SbY7k9yX5JVVtVFVN3f3s0luTXJPkkeSfKy7H97JxY0UAwCwDKYaKe7um7ZpP5HkxIVe3EgxMLppPkHZbh+jvQDzM0tN8cyMFAMAsAwWmhQDAMAymGWi3cyUTwDMxyyT6PbaBLy99n6Ai0P5BAAAw1M+AQDA8JRPAOxh1gcHmI7yCQAAhqd8AgCA4UmKAQAYnppi5s5ySHBxLHO9sL8DwKpRUwwAwPCUTwAAMDxJMQAAw5MUAwAwPBPtuGAm0sBymtcEPPc4MBIT7QAAGJ7yCQAAhicpBgBgeJJiAACGJykGAGB4kmIAAIZnSTaAAW23bNtO27eaZtm2s8+z02MsDQfsFkuyAQAwPOUTAAAMT1IMAMDwJMUAAAxPUgwAwPAkxQAADE9SDADA8Oa+TnFVvTjJXyV5Jslnu/sj874GAADM01QjxVV1e1U9VVUPndV+qKoerapTVXV00vzmJB/v7luSvHHO/QUAgLmbtnzijiSHtjZU1SVJbktyfZKDSW6qqoNJrkjyxGS378ynmwAAsHumKp/o7nur6qqzmq9Lcqq7H0uSqroryQ1JNrKZGD+Y8yTdVXUkyZEkecUrXrHTfrNkZvlqWGBvO9/fge1e242vc97p10XP66utZ+nDxTbL72i3Y7Zb19gNy/Z7XBbL/j5nmWi3P98dEU42k+H9ST6R5Neq6n1Jjm93cHcf6+717l7ft2/fDN0AAIDZzDLRrs7R1t39X0l+d6oTVB1OcvjAgQMzdAMAAGYzy0jxRpIrtzy/IsmTOzlBdx/v7iNra2szdAMAAGYzS1J8f5Jrq+rqqrosyY1J7t7JCarqcFUdO3PmzAzdAACA2Uy7JNudSe5L8sqq2qiqm7v72SS3JrknySNJPtbdD+/k4kaKAQBYBtOuPnHTNu0nkpy40IurKQYAYBks9GuejRQDALAMqrsX3YdU1ekkX1vApS9P8q0FXJf5EL/VJn6rTfxWm/itNvGbzY919/9bD3gpkuJFqaqT3b2+6H5wYcRvtYnfahO/1SZ+q038dsdCyycAAGAZSIoBABje6EnxsUV3gJmI32oTv9UmfqtN/Fab+O2CoWuKAQAgMVIMAADjJsVVdaiqHq2qU1V1dNH94buq6vGq+nJVPVhVJydtL62qf6yqr0x+/vCW/d8+ieOjVfUrW9p/anKeU1X1nqqqRbyfva6qbq+qp6rqoS1tc4tXVb2oqj46af9cVV11Md/fXrdN/N5ZVV+f3IMPVtXrt7wmfkuiqq6sqn+uqkeq6uGq+qNJu/tvBZwnfu6/Renu4bYklyT5apJrklyW5ItJDi66X7bn4/N4ksvPavvzJEcnj48meffk8cFJ/F6U5OpJXC+ZvPb5JD+bpJJ8Osn1i35ve3FL8pokr07y0G7EK8nvJ3n/5PGNST666Pe8l7Zt4vfOJH9yjn3Fb4m2JC9P8urJ45ck+bdJjNx/K7CdJ37uvwVto44UX5fkVHc/1t3PJLkryQ0L7hPnd0OSD00efyjJm7a039Xd/93d/57kVJLrqurlSX6ou+/rzb8GH95yDHPU3fcmefqs5nnGa+u5Pp7kF436z8828duO+C2R7v5Gd39h8vjbSR5Jsj/uv5VwnvhtR/x22ahJ8f4kT2x5vpHz/4fIxdVJ/qGqHqiqI5O2H+3ubySbf0iS/MikfbtY7p88Prudi2Oe8Xr+mO5+NsmZJC/btZ7znFur6kuT8ornPn4XvyU1+Vj8VUk+F/ffyjkrfon7byFGTYrP9a8ky3Asj5/v7lcnuT7JH1TVa86z73axFOPldCHxEsuL731JfjzJTyb5RpK/mLSL3xKqqh9M8rdJ/ri7//N8u56jTfwW7Bzxc/8tyKhJ8UaSK7c8vyLJkwvqC2fp7icnP59K8nfZLHf55uQjokx+PjXZfbtYbkwen93OxTHPeD1/TFVdmmQt03/czwXo7m9293e6+3+TfCCb92Aifkunqr4/mwnVR7r7E5Nm99+KOFf83H+LM2pSfH+Sa6vq6qq6LJvF53cvuE8kqaoXV9VLnnuc5HVJHspmfN462e2tST45eXx3khsnM2yvTnJtks9PPjL8dlX9zKR+6re3HMPum2e8tp7rLUn+aVI3xy55LqGa+NVs3oOJ+C2Vye/6g0ke6e6/3PKS+28FbBc/998CLXqm36K2JK/P5kzPryZ5x6L7Y3s+Ltdkc3btF5M8/FxsslkD9ZkkX5n8fOmWY94xieOj2bLCRJL1bP4x+WqS92byZTW2ucfszmx+xPc/2RyVuHme8UryA0n+JpuTSj6f5JpFv+e9tG0Tv79O8uUkX8rm/1RfLn7LtyX5hWx+FP6lJA9Otte7/1ZjO0/83H8L2nyjHQAAwxu1fAIAAJ4nKQYAYHiSYgAAhicpBgBgeJJiAACGJykGAGB4kmIAAIYnKQYAYHj/B8A94rUefwrFAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -719,12 +810,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADGCAYAAAA6wP2fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANhUlEQVR4nO3dUYil51kH8P9jQm6KjtKkKknWTdlQCaIoYywqgqAlNawRLZgoiiVk6UUEL3qxInhXzI03hVZZJZRCbSjSapZujd5ILppKNlJrYkxZw5asEZJWGVHBGn282Gk7mezsnjPfOXPOmff3g2HnfOd7z/eeeec757/vPOf9qrsDAAAj+7ZVdwAAAFZNKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4S0lFFfVL1TVH1XVn1fVe5ZxDAAAWJSZQ3FVPV5Vr1XV8/u231dVL1XVpao6myTd/Wfd/UiS30jyywvtMQAALFjNepnnqvqpJP+R5OPd/QO7225K8uUkP5vkSpJnkzzU3f+we//vJ/lEd//t9R771ltv7ZMnTx72OQAAwEyee+65r3b3bfu33zzrA3T301V1ct/me5Nc6u6Xk6SqnkjyQFW9mOSxJJ+7USBOkpMnT+bixYuzdgUAAA6lqr5yre1Ta4pvT/LKnttXdrf9ZpKfSfK+qvrAAR06U1UXq+ri66+/PrEbAABweDPPFB+grrGtu/vDST58vYbdfS7JuSTZ3t6erYYDAACWYOpM8ZUkd+65fUeSVyc+JgAAHKmpofjZJHdX1V1VdUuSB5M8OWvjqjpdVed2dnYmdgMAAA5vniXZPpnkmSTvqqorVfVwd7+R5NEkTyV5McmnuvuFWR+zu89395mtra15+w0AAAszz+oTDx2w/UKSCwvrERwjJ89+9pvfX37s/hX2BAC4Hpd5BgBgeFNXn5ikqk4nOX3q1KlVdgMOZKYXAMaw0pliNcUAAKyDlc4Uw7owIwwAYxOKYUZ7g3NycHjev98ijieoA8ByCcVwSEIrABwfPmgH+yxqpnfWYwjUALB6Kw3F3X0+yfnt7e1HVtkPmOoogjQAsDzKJ2ADmFkGgOUSijn2DgqUZncBgG8QitloAi8AsAg+aAcbTFkFACyGD9rBigm2ALB6yifgmBCuAeDwhGKODXXE1yYsA8CNCcWsleMc4IR2AFhfQjELt6hge1CIPG5hea9ZgvOi9gEAvsXqE6ycAAcArNq3rfLg3X2+u89sbW2tshsAAAxupaEYAADWgZpihqJU41uO84caAWBeQjEM5KD/FAjIAIxOKObQBCmStwZtvwsAbCKhGHgT/9kBYESWZGPjqAsGABbNkmwAAAxP+QQ3tIw/p5vtBQDWiVDMkRGEN4/6YgBGIRQDc/MfHACOG6EYmIkgDMBxJhQzF8EIADiOhGKWSogGADaBUAwsjQ/qAbAphOLBCCks2yx/HfB7CMC6WenFO6rqdFWd29nZWWU3AAAY3Epnirv7fJLz29vbj6yyH8fRUc/EqR0GADaZ8glgoyi9AGAZVlo+AQAA60AoBgBgeMonBqDel3WmHAKAdSAU8xZCNOtAWAbgKAnFJBGEWT6/YwCsMzXFAAAMz0wxsDbMJgOwKkLxwAQQAICrlE8AADA8M8UbzmwvAMB0K50prqrTVXVuZ2dnld0AAGBwKw3F3X2+u89sbW2tshsAAAxOTTEAAMMTigEAGJ4P2gFrzwdKAVg2M8UAAAzPTDGwsfbOIF9+7P4V9gSATWemGACA4Zkp3hBqKmGxzDIDsJeZYgAAhicUAwAwPKEYAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwXLxjjblgBwDA0TBTDADA8IRiAACGt/Dyiap6Z5LfSbLV3e9b9OMDXMvecqPLj91/w32mtN27zyxtAVh/M80UV9XjVfVaVT2/b/t9VfVSVV2qqrNJ0t0vd/fDy+gsAAAsw6zlEx9Lct/eDVV1U5KPJHlvknuSPFRV9yy0dwAAcARmCsXd/XSSf923+d4kl3Znhr+e5IkkDyy4fwAAsHRTaopvT/LKnttXkvxYVb09yYeS/HBV/XZ3/961GlfVmSRnkuTEiRMTugFwsKNc2nBqfbH6ZIDVmRKK6xrburu/luQDN2rc3eeSnEuS7e3tntAPAACYZMqSbFeS3Lnn9h1JXp3WHQAAOHpTZoqfTXJ3Vd2V5J+TPJjkV+Z5gKo6neT0qVOnJnQD4M2mlEwcdQmDK1cCrIdZl2T7ZJJnkryrqq5U1cPd/UaSR5M8leTFJJ/q7hfmOXh3n+/uM1tbW/P2GwAAFmammeLufuiA7ReSXFhojwAA4Ii5zDMAAMNb+GWe56Gm+K3UF8L6cD4CjGOlM8VqigEAWAfKJwAAGJ5QDADA8NQUAwzIJaUB3kxNMQAAw1M+AQDA8IRiAACGJxQDADA8oRgAgOFZfWINuGoWHD/XO69HWO3hMKtbWBEDWCWrTwAAMDzlEwAADE8oBgBgeEIxAADDE4oBABie1ScAjthRrjgzy7EOWvXhoLbzrgwxdVUJq1IAR8HqEwAADE/5BAAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDxLsi2B5YOAZTnK5dxG5PUbxmVJNgAAhqd8AgCA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8V7QDmNNRXFVulCvXHfQ8j+vzd8U8WF+uaAcAwPCUTwAAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADO/mVR68qk4nOX3q1KlVdmMuJ89+9pvfX37s/iNrC7Au9r6W7TXL69pBbaea5fX1oH2W1acpNvH9YhP7DHutdKa4u89395mtra1VdgMAgMEpnwAAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDu3nRD1hVb0vy0SRfT/LX3f2JRR8DAAAWaaaZ4qp6vKpeq6rn922/r6peqqpLVXV2d/MvJvnT7n4kyc8vuL8AALBws5ZPfCzJfXs3VNVNST6S5L1J7knyUFXdk+SOJK/s7va/i+kmAAAsz0zlE939dFWd3Lf53iSXuvvlJKmqJ5I8kORKrgbjL+Y6obuqziQ5kyQnTpyYt98LcfLsZ990+/Jj98+03422H+bYAJvuKF7X5j3Gsl+nD3rfWOSx9t63jOPN+943bx8OOtYs269nlsdahqM81jqa8vzX/Wc35YN2t+dbM8LJ1TB8e5JPJ/mlqvqDJOcPatzd57p7u7u3b7vttgndAACAaaZ80K6usa27+z+TvH/C4wIAwJGaMlN8Jcmde27fkeTVad0BAICjNyUUP5vk7qq6q6puSfJgkifneYCqOl1V53Z2diZ0AwAAppl1SbZPJnkmybuq6kpVPdzdbyR5NMlTSV5M8qnufmGeg3f3+e4+s7W1NW+/AQBgYWZdfeKhA7ZfSHJhoT0CAIAj5jLPAAAMr7p71X1IVb2e5CtzNLk1yVeX1B2Wy9htLmO3uYzd5jJ2m8vYra/v6+63rAe8FqF4XlV1sbu3V90P5mfsNpex21zGbnMZu81l7DaP8gkAAIYnFAMAMLxNDcXnVt0BDs3YbS5jt7mM3eYydpvL2G2YjawpBgCARdrUmWIAAFiYtQvFVXVfVb1UVZeq6uw17q+q+vDu/V+qqh+ZtS3LNXHsLlfV31fVF6vq4tH2nBnG7vur6pmq+u+q+uA8bVmeiePmnFuhGcbuV3dfJ79UVZ+vqh+atS3LNXHsnHfrrLvX5ivJTUn+Kck7k9yS5O+S3LNvn59L8rkkleTdSf5m1ra+1nPsdu+7nOTWVT+PEb9mHLt3JPnRJB9K8sF52vpav3Hbvc85t95j9+NJvmv3+/d6r1uPryljt3vbebfGX+s2U3xvkkvd/XJ3fz3JE0ke2LfPA0k+3ld9Icl3VtX3ztiW5ZkydqzWDceuu1/r7meT/M+8bVmaKePGas0ydp/v7n/bvfmFJHfM2palmjJ2rLl1C8W3J3llz+0ru9tm2WeWtizPlLFLkk7yl1X1XFWdWVovuZYp547zbnWm/uydc6sz79g9nKt/ZTtMWxZrytglzru1dvOqO7BPXWPb/uUxDtpnlrYsz5SxS5Kf6O5Xq+odSf6qqv6xu59eaA85yJRzx3m3OlN/9s651Zl57Krqp3M1WP3kvG1Ziiljlzjv1tq6zRRfSXLnntt3JHl1xn1macvyTBm7dPc3/n0tyWdy9U9UHI0p547zbnUm/eydcys109hV1Q8m+eMkD3T31+Zpy9JMGTvn3Zpbt1D8bJK7q+quqrolyYNJnty3z5NJfn13JYN3J9np7n+ZsS3Lc+ixq6q3VdW3J0lVvS3Je5I8f5SdH9yUc8d5tzqH/tk751buhmNXVSeSfDrJr3X3l+dpy1Ideuycd+tvrconuvuNqno0yVO5+gnPx7v7har6wO79f5jkQq6uYnApyX8lef/12q7gaQxpytgl+e4kn6mq5Orv5J90918c8VMY1ixjV1Xfk+Riku9I8n9V9Vu5+onrf3fercaUcUtya5xzKzPj6+XvJnl7ko/ujtMb3b3tvW61poxdvNetPVe0AwBgeOtWPgEAAEdOKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4f0/gihRYoA+tNQAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADGCAYAAAA6wP2fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANkUlEQVR4nO3dUYhl910H8O+vCXkpOko3Vclm3ZQJkSCKMsaiIghaNoZxRQtmFcUSsuQhgg99WBF8K+6LL4FWWSWUQk0I0mqWbI2+SB6aSjbS1sSYsoYtWSMkrbKigjH692HHOpns7J4759577p3/5wPDzj33/u/53/nPufc7//2d/6nWWgAAoGfvm7oDAAAwNaEYAIDuCcUAAHRPKAYAoHtCMQAA3ROKAQDonlAMAED3hGIAALq3kFBcVT9fVX9YVX9WVR9ZxD4AAGBeBofiqnq8qt6sqpf2bD9RVa9W1aWqOpMkrbU/ba09nOTXk/zSXHsMAABzVkMv81xVP5nk35J8prX2/TvbbknytSQ/k+RKkheSnGqt/d3O/b+X5LOttb+50XMfOXKkHT9+/KCvAQAABnnxxRe/0Vq7fe/2W4c+QWvtuao6vmfzfUkutdZeS5KqejLJyap6JcnZJF+4WSBOkuPHj+fixYtDuwIAAAdSVV+/3vaxNcV3JHl91+0rO9t+I8lPJ/loVT2yT4dOV9XFqrr41ltvjewGAAAc3OCZ4n3Udba11tpjSR67UcPW2rkk55Jka2trWA0HAAAswNiZ4itJ7tx1+2iSN0Y+JwAALNXYUPxCkrur6q6qui3Jg0meHtq4qrar6tzVq1dHdgMAAA5uliXZnkjyfJJ7qupKVT3UWnsnyaNJnk3ySpKnWmsvD33O1tr51trpjY2NWfsNAABzM8vqE6f22X4hyYW59QgOkeNnnvnW95fPPjBhTwCAG3GZZwAAujdpKFZTDADAKhi7JNsorbXzSc5vbW09PGU/YD/KHwCgD8onAADo3qQzxXAY7Z5dBgDWg1AMGVYmsTfsLrqcQukGACyPE+0AAOieE+3ggMaUSZgFBoDVonwC9ljFmmAhGgAWSyjm0NsvUK5i+AUApiEUcygJvADALCYNxVW1nWR7c3Nzym6wxpQVAADz4EQ7mNiYYO+PAgCYD1e0AwCge2qKOTR6ryMeckKh2WQAuD4zxQAAdM9MMXM3rxrZ3Q7DDGfvM9kAsMqsPgFrRrgGgPmz+gSTGxLyeqmLnVfgFZwBYDZqigEA6J5QDABA95xoR1d6LysY8voPc3kKAOzHTDEAAN0zU8yB9XLyW29mHde9s89+FwBYR5POFFfVdlWdu3r16pTdAACgc5OG4tba+dba6Y2NjSm7AQBA55RPcFOrVibR+8lyAMD8CcVMQrBdD6v2BxEALIpQzNIIwoeHsQTgsBGKgUEEYQAOM6GYmQhGAMBhJBSzUEI0ALAOhGJgYZyoB8C6EIo7I6SwCvweArBqJg3FVbWdZHtzc3PKbgBzpGQGgHU0aShurZ1Pcn5ra+vhKftxGC17Jk4QAgDWmfIJYK0ovQBgEd43dQcAAGBqQjEAAN1TPtEB9b4AADcmFPMeQjTLtF+NsNphAJZJKAaWwh9bAKwyNcUAAHTPTDFJzOKxGvweAjAVobhjAggAwDXKJwAA6J6Z4kPEzC8AwMFMGoqrajvJ9ubm5pTdWGuCMADAeJOWT7TWzrfWTm9sbEzZDQAAOqemGACA7gnFAAB0z4l2wMpTOw/AopkpBgCge2aKgbW1ewb58tkHJuwJAOvOTDEAAN0zU7wm1FTCfJllBmA3M8UAAHRPKAYAoHtCMQAA3ROKAQDonlAMAED3hGIAALonFAMA0D2hGACA7rl4xwpzwQ4AgOUwUwwAQPeEYgAAujf38omq+lCS306y0Vr76LyfH+B6dpcbXT77wE0fM6bt7scMaQvA6hs0U1xVj1fVm1X10p7tJ6rq1aq6VFVnkqS19lpr7aFFdBYAABZhaPnEp5Oc2L2hqm5J8skk9ye5N8mpqrp3rr0DAIAlGBSKW2vPJfnnPZvvS3JpZ2b47SRPJjk55/4BAMDCjakpviPJ67tuX0nyo1X1gSSfSPJDVfVbrbXfvV7jqjqd5HSSHDt2bEQ3APa3zKUNx9YXq08GmM6YUFzX2dZaa99M8sjNGrfWziU5lyRbW1ttRD8AAGCUMUuyXUly567bR5O8Ma47AACwfGNmil9IcndV3ZXkH5M8mOSXZ3mCqtpOsr25uTmiGwDvNqZkYtklDK5cCbAahi7J9kSS55PcU1VXquqh1to7SR5N8mySV5I81Vp7eZadt9bOt9ZOb2xszNpvAACYm0Ezxa21U/tsv5Dkwlx7BAAAS+YyzwAAdG/ul3mehZri91JfCKvD8QjQj0lnitUUAwCwCpRPAADQPaEYAIDuqSkG6JBLSgO8m5piAAC6p3wCAIDuCcUAAHRPKAYAoHtCMQAA3bP6xApw1Sw4fG50XPew2sNBVrewIgYwJatPAADQPeUTAAB0TygGAKB7QjEAAN0TigEA6J7VJwCWbJkrzgzZ136rPuzXdtaVIcauKmFVCmAZrD4BAED3lE8AANA9oRgAgO4JxQAAdE8oBgCge0IxAADdsyTbAlg+CFiGZS7t1gvv39AvS7IBANA95RMAAHRPKAYAoHtCMQAA3ROKAQDonlAMAED3hGIAALonFAMA0D2hGACA7rmiHcCMlnEluV6uVrff6zysr98V82B1uaIdAADdUz4BAED3hGIAALonFAMA0D2hGACA7gnFAAB0TygGAKB7QjEAAN0TigEA6J5QDABA94RiAAC6JxQDANC9W6fceVVtJ9ne3NycshszOX7mmW99f/nsA0trC7Aqdr+X7TbkfW2/tmMNeX/d7zGL6tMY6/h5sY59ht0mnSlurZ1vrZ3e2NiYshsAAHRO+QQAAN0TigEA6J5QDABA94RiAAC6JxQDANA9oRgAgO4JxQAAdE8oBgCge0IxAADdE4oBAOieUAwAQPeEYgAAuicUAwDQPaEYAIDuCcUAAHRPKAYAoHtCMQAA3ROKAQDo3q3zfsKqen+STyV5O8lftdY+O+99AADAPA2aKa6qx6vqzap6ac/2E1X1alVdqqozO5t/IcmftNYeTvJzc+4vAADM3dDyiU8nObF7Q1XdkuSTSe5Pcm+SU1V1b5KjSV7fedh/z6ebAACwOIPKJ1prz1XV8T2b70tyqbX2WpJU1ZNJTia5kmvB+Mu5QeiuqtNJTifJsWPHZu33XBw/88y7bl8++8Cgx91s+0H2DbDulvG+Nus+Fv0+vd/nxjz3tfu+Rexv1s++Wfuw376GbL+RIc+1CMvc1yoa8/pX/Wc35kS7O/L/M8LJtTB8R5LPJfnFqvr9JOf3a9xaO9da22qtbd1+++0jugEAAOOMOdGurrOttdb+PcnHRjwvAAAs1ZiZ4itJ7tx1+2iSN8Z1BwAAlm9MKH4hyd1VdVdV3ZbkwSRPz/IEVbVdVeeuXr06ohsAADDO0CXZnkjyfJJ7qupKVT3UWnsnyaNJnk3ySpKnWmsvz7Lz1tr51trpjY2NWfsNAABzM3T1iVP7bL+Q5MJcewQAAEvmMs8AAHSvWmtT9yFV9VaSr8/Q5EiSbyyoOyyWsVtfxm59Gbv1ZezWl7FbXd/bWnvPesArEYpnVVUXW2tbU/eD2Rm79WXs1pexW1/Gbn0Zu/WjfAIAgO4JxQAAdG9dQ/G5qTvAgRm79WXs1pexW1/Gbn0ZuzWzljXFAAAwT+s6UwwAAHOzcqG4qk5U1atVdamqzlzn/qqqx3bu/2pV/fDQtizWyLG7XFV/W1VfrqqLy+05A8bu+6rq+ar6z6r6+CxtWZyR4+aYm9CAsfuVnffJr1bVF6vqB4e2ZbFGjp3jbpW11lbmK8ktSf4hyYeS3JbkK0nu3fOYn03yhSSV5MNJ/npoW1+rOXY7911OcmTq19Hj18Cx+2CSH0nyiSQfn6Wtr9Ubt537HHOrPXY/luQ7d76/32fdanyNGbud2467Ff5atZni+5Jcaq291lp7O8mTSU7ueczJJJ9p13wpyXdU1fcMbMvijBk7pnXTsWutvdlaeyHJf83aloUZM25Ma8jYfbG19i87N7+U5OjQtizUmLFjxa1aKL4jyeu7bl/Z2TbkMUPasjhjxi5JWpK/qKoXq+r0wnrJ9Yw5dhx30xn7s3fMTWfWsXso1/6X7SBtma8xY5c47lbarVN3YI+6zra9y2Ps95ghbVmcMWOXJD/eWnujqj6Y5C+r6u9ba8/NtYfsZ8yx47ibztifvWNuOoPHrqp+KteC1U/M2paFGDN2ieNupa3aTPGVJHfuun00yRsDHzOkLYszZuzSWvu/f99M8vlc+y8qlmPMseO4m86on71jblKDxq6qfiDJHyU52Vr75ixtWZgxY+e4W3GrFopfSHJ3Vd1VVbcleTDJ03se83SSX9tZyeDDSa621v5pYFsW58BjV1Xvr6pvS5Kqen+SjyR5aZmd79yYY8dxN50D/+wdc5O76dhV1bEkn0vyq621r83SloU68Ng57lbfSpVPtNbeqapHkzyba2d4Pt5ae7mqHtm5/w+SXMi1VQwuJfmPJB+7UdsJXkaXxoxdku9K8vmqSq79Tv5xa+3Pl/wSujVk7Krqu5NcTPLtSf6nqn4z1864/lfH3TTGjFuSI3HMTWbg++XvJPlAkk/tjNM7rbUtn3XTGjN28Vm38lzRDgCA7q1a+QQAACydUAwAQPeEYgAAuicUAwDQPaEYAIDuCcUAAHRPKAYAoHtCMQAA3ftfgTJKWSyRyPUAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -746,12 +837,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADGCAYAAAA6wP2fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANzElEQVR4nO3dX4ylZ10H8O/PVjBBnAithmxbt7gNSeOF1EnVaLhRsYWsRW1i64VoGjZEa/TCiyXccGOsJnjRiJglNoAhLYgo3VACxj/pTQPdkgKtm8KCJV3a0CLJiF6IxZ8Xc1pOpzPbM3vOzDkzz+eTvJkzz5z3Pc/sr+/pd57zvM9b3R0AABjZ9y27AwAAsGxCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMb09CcVW9pareV1Ufr6o37sVrAADAoswciqvqrqp6uqoe2dJ+Q1U9VlXnqupkknT3P3T325L8dpLfWGiPAQBgwWrW2zxX1RuS/FeSD3b3T0zaLknypSS/lOR8kgeT3Nrd/zb5+buTfKi7P3ehY1922WV99OjRi/0dAABgJg899NA3u/vyre2XznqA7r6/qo5uab4+ybnu/mqSVNU9SW6qqrNJ7kjyyZcKxEly9OjRnDlzZtauAADARamqr23XPu+c4iNJnpj6/vyk7feT/GKSm6vq7Tt06ERVnamqM88888yc3QAAgIs380jxDmqbtu7uO5PceaEdu/tUklNJsr6+PtscDgAA2APzjhSfT3Ll1PdXJHlyzmMCAMC+mjcUP5jkmqq6uqpeluSWJPfOunNVHa+qUxsbG3N2AwAALt5ulmS7O8kDSV5XVeer6rbufjbJ7Uk+leRsko9096OzHrO7T3f3ibW1td32GwAAFmY3q0/cukP7fUnuW1iPGNrRk594/vHjd7x5iT0BAEbiNs8AAAxv3tUn5lJVx5McP3bs2DK7wR5a1sivEWcAYDeWGoq7+3SS0+vr629bZj9YrukAuwrHAQDGs9RQDBfDKDAAsGhCMUtxUEZ1BXAAGINQzL7ZiyA8yzF3CrYCLwDwnKWuPuHmHQAArAIX2rErRlcBgMPI9AmGMs8Ujq37+qMAAA4PoZiVtQprHAMAYxCKORAEVQBgL7mjHQshtH6PedcAcPC40A4i1APA6Ja6JBsAAKwCc4phAYw0A8DBZqQYAIDhGSmGfeICPABYXVaf4KKZMgAAHBZWn4Al2+mPC6PJALB/zCkGAGB45hTzIltHLo1Ybm+W6SM7PcfUEwBYLUaKAQAYnlAMAMDwTJ8YmCXCDg61AoC9tdSR4qo6XlWnNjY2ltkNAAAGZ0k2OGCMGgPA4pk+AStqt6tbCMgAcPFcaAcAwPCMFAMzMSoNwGEmFJPEzSQAgLEJxbwkgflg2+0IrxFhAEZkTjEAAMMTigEAGJ7pE4MxFQIA4MXc0Q4AgOEtNRR39+nuPrG2trbMbgAAMDhzigEAGJ5QDADA8IRiAACGJxQDADA8S7IdIu5ExqJZwg+AUQjFh5SAzG7sNvz67wuAw8b0CQAAhmekGAZihBcAticUwyFkLjAA7I7pEwAADM9I8QCMGo5hnovlAGB0Sx0prqrjVXVqY2Njmd0AAGBwSw3F3X26u0+sra0tsxsAAAzO9Algz1jtAoCDwoV2AAAMz0jxAWHEDQBg7xgpBgBgeEaKgblsXdrNJxkAHERGigEAGJ5QDADA8IRiAACGZ04xsC9mWUHFKisALIuRYgAAhmekGFioratRvNRzjAgDsAqMFAMAMDyhGACA4Zk+sWJ8rMxodppu4VwAYD8ZKQYAYHhGig+4WS5qAgDgwowUAwAwPKEYAIDhLXz6RFW9Nsk7k6x1982LPj7Ac3aaPuTCPAB2a6aR4qq6q6qerqpHtrTfUFWPVdW5qjqZJN391e6+bS86CwAAe2HW6RPvT3LDdENVXZLkPUluTHJtklur6tqF9g4AAPbBTKG4u+9P8q0tzdcnOTcZGf5OknuS3LTg/gEAwJ6bZ07xkSRPTH1/PslPV9Wrk/xxktdX1Tu6+0+227mqTiQ5kSRXXXXVHN0AeKGdbvzhhiAA7GSeUFzbtHV3/0eSt7/Uzt19KsmpJFlfX+85+gEAAHOZZ0m280munPr+iiRPztcdAADYf/OMFD+Y5JqqujrJ15PckuQ3d3OAqjqe5PixY8fm6MbhtdNyU+5ix2hMewBgr826JNvdSR5I8rqqOl9Vt3X3s0luT/KpJGeTfKS7H93Ni3f36e4+sba2ttt+AwDAwsw0Utzdt+7Qfl+S+xbaIwAA2Gdu8wwAwPCWGoqr6nhVndrY2FhmNwAAGNxSQ7E5xQAArALTJwAAGJ5QDADA8OZZp3hu1ikGduugrtNtrWWA1WZOMQAAwzN9AgCA4QnFAAAMTygGAGB4QjEAAMOz+sQKOKhX08NBsNP5ZTUIAKZZfQIAgOGZPgEAwPCEYgAAhicUAwAwPKEYAIDhWX0CYAZWqwA43Kw+AQDA8EyfAABgeEIxAADDE4oBABieUAwAwPCEYgAAhmdJNoAp00uv7fb5sy7VZnk3gNVjSTYAAIZn+gQAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeO5otwfcrQoOt1nuerfbO+Nt3Wen9w7vLwB7wx3tAAAYnukTAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDu3SZL15Vx5McP3bs2DK78ZKOnvzE848fv+PNCz8msFyLOh8v5jjLei9Y1PvaLMfZi/fQWS3ztYGDZakjxd19urtPrK2tLbMbAAAMzvQJAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPCEYgAAhicUAwAwPKEYAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMLxLF33AqnpFkr9M8p0k/9rdH1r0awAAwCLNNFJcVXdV1dNV9ciW9huq6rGqOldVJyfNv5bko939tiS/suD+AgDAws06feL9SW6YbqiqS5K8J8mNSa5NcmtVXZvkiiRPTJ723cV0EwAA9s5M0ye6+/6qOrql+fok57r7q0lSVfckuSnJ+WwG44dzgdBdVSeSnEiSq666arf9XoijJz/xgu8fv+PNF73/LPtufT2Anczz/jL9/N2+78zyurMcc973u932Y57febd2W5sR7VSDVfz3Gr2e+/n7r/q/9TwX2h3J90aEk80wfCTJx5L8elW9N8npnXbu7lPdvd7d65dffvkc3QAAgPnMc6FdbdPW3f3fSX5njuMCAMC+mmek+HySK6e+vyLJk/N1BwAA9t88ofjBJNdU1dVV9bIktyS5dzcHqKrjVXVqY2Njjm4AAMB8Zl2S7e4kDyR5XVWdr6rbuvvZJLcn+VSSs0k+0t2P7ubFu/t0d59YW1vbbb8BAGBhZl194tYd2u9Lct9CewQAAPvMbZ4BABhedfey+5CqeibJ15bdjwPqsiTfXHYn2FdqPiZ1H4+aj0fN98ePdfeL1gNeiVDMxauqM929vux+sH/UfEzqPh41H4+aL5fpEwAADE8oBgBgeELxwXdq2R1g36n5mNR9PGo+HjVfInOKAQAYnpFiAACGJxSvoKp6vKq+WFUPV9WZSdurquofq+rLk68/PPX8d1TVuap6rKp+ear9pybHOVdVd1ZVLeP34cWq6q6qerqqHplqW1iNq+rlVfXhSftnqurofv5+bG+Hur+rqr4+Od8frqo3Tf1M3Q+4qrqyqv6lqs5W1aNV9QeTduf7IXWBmjvXV11321ZsS/J4ksu2tP1ZkpOTxyeT/Onk8bVJPp/k5UmuTvKVJJdMfvbZJD+bpJJ8MsmNy/7dbM/X8w1JrkvyyF7UOMnvJvmryeNbknx42b+zbce6vyvJH23zXHU/BFuS1yS5bvL4lUm+NKmt8/2QbheouXN9xTcjxQfHTUk+MHn8gSRvmWq/p7v/p7v/Pcm5JNdX1WuS/FB3P9CbZ80Hp/Zhybr7/iTf2tK8yBpPH+ujSX7BJwXLt0Pdd6Luh0B3P9Xdn5s8/naSs0mOxPl+aF2g5jtR8xUhFK+mTvLpqnqoqk5M2n60u59KNk+4JD8yaT+S5Impfc9P2o5MHm9tZ3UtssbP79PdzybZSPLqPes587q9qr4wmV7x3Mfo6n7ITD7ifn2Sz8T5PoQtNU+c6ytNKF5NP9fd1yW5McnvVdUbLvDc7f4y7Au0c/BcTI3V/+B4b5IfT/KTSZ5K8u5Ju7ofIlX1g0n+Lskfdvd/Xuip27Sp+wG0Tc2d6ytOKF5B3f3k5OvTSf4+yfVJvjH5KCWTr09Pnn4+yZVTu1+R5MlJ+xXbtLO6Flnj5/epqkuTrGX2j+3ZR939je7+bnf/X5L3ZfN8T9T90Kiq789mOPpQd39s0ux8P8S2q7lzffUJxSumql5RVa987nGSNyZ5JMm9Sd46edpbk3x88vjeJLdMrkS9Osk1ST47+Tju21X1M5N5Rr81tQ+raZE1nj7WzUn+eTInjRXzXDCa+NVsnu+Juh8Kkxr9dZKz3f3nUz9yvh9SO9XcuX4ALPtKP9sLtySvzeZVqJ9P8miSd07aX53kn5J8efL1VVP7vDObV6s+lqkVJpKsZ/Ok+0qSv8jkZi225W9J7s7mx2f/m82/+G9bZI2T/ECSv83mBRufTfLaZf/Oth3r/jdJvpjkC9n8H91r1P3wbEl+Ppsfa38hycOT7U3O98O7XaDmzvUV39zRDgCA4Zk+AQDA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABje/wPENgcQDUvD5AAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADGCAYAAAA6wP2fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAN40lEQVR4nO3dX6xlV10H8O+PVjBBvJF2NGTacYrTkDQ+SJ00Gg0vKrY0Y1FJbH0QTdMJ0Rp98GEILzxWE3wgImSIDWBICyJKJ5Sg8U/60kBbUqBlUjrUkg4lVDQZ0Qe1+PPhnpbL7b3Tc+ece/e5d30+yc7dZ939Z52u2affu87aa1d3BwAARvaKqSsAAABTE4oBABieUAwAwPCEYgAAhicUAwAwPKEYAIDhCcUAAAxPKAYAYHi7Eoqr6q1V9cGq+lRVvXk3zgEAAMsydyiuqrur6rmqemxT+Y1V9URVnauqU0nS3X/b3Xck+e0kv7HUGgMAwJLVvI95rqo3JfnPJB/p7p+clV2W5KtJfinJ+SQPJbmtu78y+/17kny0u79wsWNfeeWVffTo0Ut9DwAAMJdHHnnk2919aHP55fMeoLsfqKqjm4pvSHKuu59Kkqq6N8ktVXU2yV1JPrNdIK6qk0lOJsmRI0fy8MMPz1sVAAC4JFX19a3KFx1TfDjJMxten5+V/X6SX0zytqp6x1Y7dvfp7j7e3ccPHXpJWAcAgD0zd0/xNmqLsu7u9yZ574LHBgCAPbFoT/H5JFdveH1VkmcXPCYAAOypRUPxQ0muraprquqVSW5Nct+8O1fViao6feHChQWrAQAAl24nU7Ldk+TBJG+oqvNVdXt3P5/kziSfTXI2yce7+/F5j9ndZ7r75Nra2k7rDQAAS7OT2Sdu26b8/iT3L61GDO3oqU+/uP70XTdPWBMAYCQe8wwAwPAWnX1iIVV1IsmJY8eOTVkNdtE8Pb8bt9nL8wIAvGDSnmJjigEAWAWT9hTDMu1GjzMAMAahmEksEmCXNTTCEAsA4AXGFMNFCM4AMIZJQ3F3n0ly5vjx43dMWQ/2xm7fUDfPNoItALAVwyfYEQETADiIhGKGsqyxzIk/CgDgIBGKYROzWADAeNxox8oSTgGAveJGO1gy464BYP8xfIKlEAQBgP1MKGbp9uOwh/1YZwBgeV4xdQUAAGBqeophCfQ0A8D+ZvYJ2CPGXQPA6jL7BExMWAaA6Rk+AStEQAaAaQjFXDLjaAGAg0Io5iU2h109llub54+C7bbxBwUArBZTsgEAMDyhGACA4Rk+MTA3de0f2goAdtekPcVVdaKqTl+4cGHKagAAMLhJQ3F3n+nuk2tra1NWAwCAwRk+AStqpzNXGFYBAJdOKAbmYlwzAAeZ2ScAABienmKSeJjEQaaHFwBenlDMyxKYxyJEAzAiwycAABienuLB6PUFAHgpPcUAAAzPE+0AABieJ9oBADA8wycAABieUAwAwPCEYgAAhicUAwAwPPMUHyCeRMaymdcagFEIxQeUgMxO7DT8+vcFwEEjFMNAhFkA2JoxxQAADE9PMRxAxgIDwM7oKQYAYHh6igeg15Ct+HcBAN8zaSiuqhNJThw7dmzKasCBIOQCwKWbdPhEd5/p7pNra2tTVgMAgMEZPgHsGlPAAbBfuNEOAIDh6SneJ/S4AQDsHj3FAAAMT08xsJDNs174JgOA/UhPMQAAwxOKAQAYnlAMAMDwjCkG9sQ8M6iYZQWAqegpBgBgeHqKgaXaPBvFy22jRxiAVaCnGACA4QnFAAAMz/CJFeNrZUaz3XAL1wIAe0lPMQAAw9NTvM/Nc1MTAAAXp6cYAIDhCcUAAAxv6cMnqur1Sd6VZK2737bs4wO8YLvhQ27MA2Cn5uoprqq7q+q5qnpsU/mNVfVEVZ2rqlNJ0t1Pdfftu1FZAADYDfMOn/hQkhs3FlTVZUnel+SmJNclua2qrltq7QAAYA/MNXyiux+oqqObim9Icq67n0qSqro3yS1JvjLPMavqZJKTSXLkyJE5qwvw8rab49jcxwBsZ5Eb7Q4neWbD6/NJDlfVFVX1gSRvrKp3brdzd5/u7uPdffzQoUMLVAMAABazyI12tUVZd/e/JXnHAscFAIA9tUhP8fkkV294fVWSZxerDgAA7L1FeoofSnJtVV2T5BtJbk3ymzs5QFWdSHLi2LFjC1Tj4NpuuilPsWM0xgIDsNvmnZLtniQPJnlDVZ2vqtu7+/kkdyb5bJKzST7e3Y/v5OTdfaa7T66tre203gAAsDTzzj5x2zbl9ye5f6k1AgCAPeYxzwAADG/SUFxVJ6rq9IULF6asBgAAg5s0FBtTDADAKjB8AgCA4QnFAAAMb5F5ihdmnmJgp8zTDcBuMKYYAIDhGT4BAMDwhGIAAIYnFAMAMLzq7ulO/r0b7e548sknJ6vH1Nw4BNN6+q6bd/0cG6/zvTgfAFurqke6+/jmcjfaAQAwPMMnAAAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4V0+5ck3TMk2ZTUAXpYp1QAONlOyAQAwPMMnAAAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4ZmSDWCDjVOv7XT7eadqM70bwOoxJRsAAMMzfAIAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPCEYgAAhicUAwAwPE+02wWeVgUH2zxPvdvpk/E277PdZ4fPF4Dd4Yl2AAAMz/AJAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPCEYgAAhicUAwAwPKEYAIDhXT7lyavqRJITx44dm7IaL+voqU+/uP70XTcv/ZjAtJZ1PV7Kcab6LFjW59o8x9mNz9B5TXluYH+ZtKe4u89098m1tbUpqwEAwOAMnwAAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDu3zZB6yqVyf58yT/k+Sfu/ujyz4HAAAs01w9xVV1d1U9V1WPbSq/saqeqKpzVXVqVvxrST7R3Xck+ZUl1xcAAJZu3uETH0py48aCqrosyfuS3JTkuiS3VdV1Sa5K8sxss+8up5oAALB75ho+0d0PVNXRTcU3JDnX3U8lSVXdm+SWJOezHowfzUVCd1WdTHIySY4cObLTei/F0VOf/r7XT9918yXvP8++m88HsJ1FPl82br/Tz515zjvPMRf9vNtpPRZ5zzu107YZ0XZtsIr/vUZvz718/6v+33qRG+0O53s9wsl6GD6c5JNJfr2q3p/kzHY7d/fp7j7e3ccPHTq0QDUAAGAxi9xoV1uUdXf/V5LfWeC4AACwpxbpKT6f5OoNr69K8uxi1QEAgL23SCh+KMm1VXVNVb0yya1J7tvJAarqRFWdvnDhwgLVAACAxcw7Jds9SR5M8oaqOl9Vt3f380nuTPLZJGeTfLy7H9/Jybv7THefXFtb22m9AQBgaeadfeK2bcrvT3L/UmsEAAB7zGOeAQAYXnX31HVIVf1rkq9PXY996sok3566EuwpbT4m7T4ebT4ebb43fry7XzIf8EqEYi5dVT3c3cenrgd7R5uPSbuPR5uPR5tPy/AJAACGJxQDADA8oXj/Oz11Bdhz2nxM2n082nw82nxCxhQDADA8PcUAAAxPKAYAYHhC8Qqqqqer6stV9WhVPTwre21V/X1VPTn7+SMbtn9nVZ2rqieq6pc3lP/07Djnquq9VVVTvB9eqqrurqrnquqxDWVLa+OqelVVfWxW/rmqOrqX74+tbdPu766qb8yu90er6i0bfqfd97mqurqq/qmqzlbV41X1B7Ny1/sBdZE2d62vuu62rNiS5OkkV24q+5Mkp2brp5L88Wz9uiRfTPKqJNck+VqSy2a/+3ySn01SST6T5Kap35vlxfZ8U5Lrkzy2G22c5HeTfGC2fmuSj039ni3btvu7k/zRFttq9wOwJHldkutn669J8tVZ27reD+hykTZ3ra/4oqd4/7glyYdn6x9O8tYN5fd29393978kOZfkhqp6XZIf7u4He/2q+ciGfZhYdz+Q5N83FS+zjTce6xNJfsE3BdPbpt23o90PgO7+Znd/Ybb+nSRnkxyO6/3Aukibb0ebrwiheDV1kr+rqkeq6uSs7Me6+5vJ+gWX5Edn5YeTPLNh3/OzssOz9c3lrK5ltvGL+3T380kuJLli12rOou6sqi/Nhle88DW6dj9gZl9xvzHJ5+J6H8KmNk9c6ytNKF5NP9fd1ye5KcnvVdWbLrLtVn8Z9kXK2X8upY21//7x/iQ/keSnknwzyXtm5dr9AKmqH0ry10n+sLv/42KbblGm3fehLdrctb7ihOIV1N3Pzn4+l+RvktyQ5Fuzr1Iy+/ncbPPzSa7esPtVSZ6dlV+1RTmra5lt/OI+VXV5krXM/7U9e6i7v9Xd3+3u/0vywaxf74l2PzCq6geyHo4+2t2fnBW73g+wrdrctb76hOIVU1WvrqrXvLCe5M1JHktyX5K3zzZ7e5JPzdbvS3Lr7E7Ua5Jcm+Tzs6/jvlNVPzMbZ/RbG/ZhNS2zjTce621J/nE2Jo0V80IwmvnVrF/viXY/EGZt9BdJznb3n274lev9gNquzV3r+8DUd/pZvn9J8vqs34X6xSSPJ3nXrPyKJP+Q5MnZz9du2OddWb9b9YlsmGEiyfGsX3RfS/JnmT3B0DL9kuSerH999r9Z/4v/9mW2cZIfTPJXWb9h4/NJXj/1e7Zs2+5/meTLSb6U9f/RvU67H5wlyc9n/WvtLyV5dLa8xfV+cJeLtLlrfcUXj3kGAGB4hk8AADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPD+H42ZChszuElyAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -773,12 +864,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsoAAADCCAYAAABQWuQEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAORElEQVR4nO3dX6ykZ10H8O/Plj8G8Ci0GtI/bnEbkoYYwJOC0XAjwRZcwT8JrReiaboxWqMXXpRgDF4Yi4kmEhGySAMa0oL4h24oQaKS3jSULRZoUytLrelSQkHiil6IxZ8XZ8DT7XPWOZ05+87Mfj7Jm515zjvvPHOe806++8zvfaa6OwAAwJN9x9QdAACAVSQoAwDAgKAMAAADgjIAAAwIygAAMCAoAwDAwIVTdyBJLrrooj506NDU3QAAYMPde++9X+3ui+fZdyWC8qFDh3LixImpuwEAwIarqn+Zd1+lFwAAMHAgQbmq3lBV766qD1fVaw7iOQAA4CDNHZSr6taqeryq7j+j/ZqqeqiqTlbVzUnS3X/d3Tcm+YUkb1xqjwEA4BzYz4zye5Ncs7uhqi5I8o4k1ya5Ksn1VXXVrl1+c/ZzAABYK3MH5e6+K8nXzmi+OsnJ7n64u7+R5PYkr68db0vy0e7+9Oh4VXW0qk5U1YmvfOUrT7f/AABwIBZd9eKSJI/uun8qySuS/GqSVyfZqqrD3f2uMx/Y3ceSHEuS7e3tXrAfbLhDN3/k27cfueV1E/YEADhfLBqUa9DW3f32JG9f8NiwL8I0ALBMi656cSrJZbvuX5rksQWPCQAAk1s0KH8qyZVVdUVVPTPJdUnumPfBVXWkqo6dPn16wW4AAMBy7Wd5uNuS3J3kxVV1qqpu6O4nktyU5GNJHkzywe5+YN5jdvfx7j66tbW1334DAMCBmrtGubuv36P9ziR3Lq1HAACwAha9mI/z2CZdPLdJrwUAWI5Jg3JVHUly5PDhw1N2gwO0O4DutlcY3W9g3ev4AACLmjQod/fxJMe3t7dvnLIfnHvzBGIhGACY0qKrXgAAwEZSo8zGW6ScQ70yAJy/1CizkfYq2xCCAYB5TVp6YR1lAABWldILlu6gL8Jb1vFdLAgAnI2gzL4cRLgUWAGAVVTdPXUfsr293SdOnJi6G+xBkN2hphkA1l9V3dvd2/PsO2mNclUdqapjp0+fnrIbAADwFC7mAwCAAV84AgAAAy7mgwNk3WYAWF9mlAEAYMCMMszpzNU/zBADwGaz6gUAAAxMOqPc3ceTHN/e3r5xyn7wZNZN3j+1yACwedQoAwDAgBplWDIz8gCwGQRlWFHKOQBgWoIyScyCPh1+ZwCw2QTl84xZyunsFayNAwCspkmDclUdSXLk8OHDU3bjvGVGFABgb9XdU/ch29vbfeLEiam7cV4QjtefGWgAePqq6t7u3p5nX8vDAQDAgBplWDPqzAHg3BCUzwPKLQAA9k/pBQAADAjKAAAwoPQCeBI10ACwQ1CGNbbfUCsEA8D8fOEIbAghGACWa9Ia5e4+3t1Ht7a2puwGAAA8hYv5AABgQI0ynKeUagDA2ZlRBgCAATPKG8q38QEALMaMMgAADAjKAAAwoPQCNpAL9QBgcYLymlOLzEESuAE4nym9AACAAUEZAAAGBGUAABgQlAEAYGDSoFxVR6rq2OnTp6fsBgAAPMWkq1509/Ekx7e3t2+csh/A/lgNA4DzgdILAAAYsI4ybDhrbQPA02NGGQAABgRlAAAYEJQBAGBAjTKgjhkABswoAwDAgBllYCFnzkbPs66ydZgBWAdmlAEAYEBQBgCAAUEZAAAGBGUAABgQlAEAYEBQBgCAAcvDrQnLabHu9vpSE3/bAKwqM8oAADCw9KBcVS+qqvdU1YeWfWwAADhX5iq9qKpbk/xEkse7+yW72q9J8odJLkjyJ919S3c/nOQGQXlx83xUDefKufi7U4YBwCqZd0b5vUmu2d1QVRckeUeSa5NcleT6qrpqqb0DAICJzBWUu/uuJF87o/nqJCe7++Hu/kaS25O8fsn9AwCASSyy6sUlSR7ddf9UkldU1QuS/E6Sl1XVm7v7d0cPrqqjSY4myeWXX75AN4BVddDlGko1ADhIiwTlGrR1d/9rkl/6/x7c3ceSHEuS7e3tXqAfAACwdIusenEqyWW77l+a5LHFugMAAKthkRnlTyW5sqquSPLFJNcl+bn9HKCqjiQ5cvjw4QW6sVmsaAEAsBrmmlGuqtuS3J3kxVV1qqpu6O4nktyU5GNJHkzywe5+YD9P3t3Hu/vo1tbWfvsNAAAHaq4Z5e6+fo/2O5PcudQeAQDACvAV1gAAMLBIjfLC1CjvUJcMi7NUHADLNumMshplAABWldILAAAYEJQBAGBAjTKwVMuqud+r5ni/x1e7DMDTpUYZAAAGlF4AAMCAoAwAAAOCMgAADLiYD1h5B32BIACMuJgPAAAGlF4AAMCAoAwAAAOCMgAADAjKAAAwYNWLiSzrKn7g4FglA+D8ZtULAAAYUHoBAAADgjIAAAwIygAAMCAoAwDAgKAMAAADgjIAAAxYRxlgxVnPGWAa1lEGAIABpRcAADAgKAMAwICgDAAAA4IyAAAMCMoAADAgKAMAwICgDAAAA75wZAH7/RKA3fsD01qVL/HY633BF4sATM8XjgAAwIDSCwAAGBCUAQBgQFAGAIABQRkAAAYEZQAAGBCUAQBgQFAGAIABQRkAAAYEZQAAGBCUAQBgQFAGAICBC6d88qo6kuTI4cOHp+zG0h26+SNTdwHOa/s9B3fv/8gtrztnj533uAdxzGX2FWBTTTqj3N3Hu/vo1tbWlN0AAICnUHoBAAADgjIAAAwIygAAMCAoAwDAgKAMAAADgjIAAAwIygAAMCAoAwDAgKAMAAADgjIAAAwIygAAMCAoAwDAgKAMAAADgjIAAAwIygAAMCAoAwDAgKAMAAADFy77gFX1nCR/nOQbST7R3e9f9nMAAMBBm2tGuapurarHq+r+M9qvqaqHqupkVd08a/7pJB/q7huT/OSS+wsAAOfEvKUX701yze6GqrogyTuSXJvkqiTXV9VVSS5N8uhst28up5sAAHBuzVV60d13VdWhM5qvTnKyux9Okqq6Pcnrk5zKTli+L2cJ4lV1NMnRJLn88sv32++lOHTzR550/5FbXre0YwGba6/zfd73gUXea+YxTz/22mevvu3ef5nvlQf9u9jruQ/6dR70MVfd+fial2W/5+Y6Wce/i0Uu5rsk/zdznOwE5EuS/GWSn6mqdyY5vteDu/tYd2939/bFF1+8QDcAAGD5FrmYrwZt3d3/meQXFzguAABMbpEZ5VNJLtt1/9Ikjy3WHQAAWA2LBOVPJbmyqq6oqmcmuS7JHfs5QFUdqapjp0+fXqAbAACwfPMuD3dbkruTvLiqTlXVDd39RJKbknwsyYNJPtjdD+znybv7eHcf3dra2m+/AQDgQM276sX1e7TfmeTOpfYIAABWgK+wBgCAgeru6Z686kiSI0nemOTzk3VkvV2U5KtTd4KlMZ6bw1huFuO5WYznZtnveH5/d8+1NvGkQZnFVdWJ7t6euh8sh/HcHMZysxjPzWI8N8tBjqfSCwAAGBCUAQBgQFBef8em7gBLZTw3h7HcLMZzsxjPzXJg46lGGQAABswoAwDAgKC8gqrqkar6XFXdV1UnZm3Pr6qPV9XnZ/9+z67931xVJ6vqoar68V3tPzQ7zsmqentV1RSv53xTVbdW1eNVdf+utqWNX1U9q6o+MGv/ZFUdOpev73yzx3i+taq+ODtH76uq1+76mfFcUVV1WVX9fVU9WFUPVNWvzdqdn2voLOPp/FxDVfXsqrqnqj4zG8/fnrVPe352t23FtiSPJLnojLbfS3Lz7PbNSd42u31Vks8keVaSK5J8IckFs5/dk+SHk1SSjya5durXdj5sSV6V5OVJ7j+I8Uvyy0neNbt9XZIPTP2aN3nbYzzfmuQ3BvsazxXekrwwyctnt5+X5J9mY+b8XMPtLOPp/FzDbfa7f+7s9jOSfDLJK6c+P80or4/XJ3nf7Pb7krxhV/vt3f1f3f3PSU4mubqqXpjku7r77t75i/jTXY/hAHX3XUm+dkbzMsdv97E+lOTHfFpwcPYYz70YzxXW3V/q7k/Pbn89yYNJLonzcy2dZTz3YjxXWO/4j9ndZ8y2zsTnp6C8mjrJ31TVvVV1dNb2fd39pWTnzSHJ987aL0ny6K7Hnpq1XTK7fWY701jm+H37Md39RJLTSV5wYD1nLzdV1WdnpRnf+ijQeK6J2UeuL8vOrJXzc82dMZ6J83MtVdUFVXVfkseTfLy7Jz8/BeXV9CPd/fIk1yb5lap61Vn2Hf1PqM/Szmp5OuNnbKf3ziQ/kOSlSb6U5Pdn7cZzDVTVc5P8RZJf7+5/P9uugzbjuWIG4+n8XFPd/c3ufmmSS7MzO/ySs+x+TsZTUF5B3f3Y7N/Hk/xVkquTfHn2cUJm/z4+2/1Ukst2PfzSJI/N2i8dtDONZY7ftx9TVRcm2cr8pQEsQXd/efaG/j9J3p2dczQxniuvqp6RnVD1/u7+y1mz83NNjcbT+bn+uvvfknwiyTWZ+PwUlFdMVT2nqp73rdtJXpPk/iR3JHnTbLc3Jfnw7PYdSa6bXcl5RZIrk9wz+3ji61X1yln9zc/vegzn3jLHb/exfjbJ383qsDhHvvWmPfNT2TlHE+O50ma/+/ckebC7/2DXj5yfa2iv8XR+rqequriqvnt2+zuTvDrJP2bq8/Mgr2C0Pa2rPl+Unas4P5PkgSRvmbW/IMnfJvn87N/n73rMW7JztedD2bWyRZLt7LxBfCHJH2X2BTO2Ax/D27Lzcd9/Z+d/rzcsc/ySPDvJn2fnwoV7krxo6te8ydse4/lnST6X5LOzN94XGs/V35L8aHY+Zv1skvtm22udn+u5nWU8nZ9ruCX5wST/MBu3+5P81qx90vPTN/MBAMCA0gsAABgQlAEAYEBQBgCAAUEZAAAGBGUAABgQlAEAYEBQBgCAAUEZAAAG/hc+/gWwHjDnxwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsoAAADCCAYAAABQWuQEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOBElEQVR4nO3dUYxld10H8O/PFsEAjkKrIbutW9yGZEMM4KRiNLxIcAuuRSWh5UE0TTdEa/TBhyUYgw/GYqKJRMQs0oCGtCCisKEEiUr60lC22EKbWllqTbclLEhc0Qex+PNhLnjZnlnu7L0z5947n09yMvf+55xz/zP/OTff+d/fOae6OwAAwLf7rrE7AAAAy0hQBgCAAYIyAAAMEJQBAGCAoAwAAAMEZQAAGHD52B1IkiuuuKIPHTo0djcAAFhz991331e6+8pZ1l2KoHzo0KGcPn167G4AALDmqupfZ113V0ovquq1VfWuqvpwVb1qN14DAAB208xBuapur6pzVfXgBe1Hq+qRqjpTVSeSpLv/prtvSfJLSV6/0B4DAMAe2MmM8nuSHJ1uqKrLkrwjyfVJjiS5qaqOTK3yW5PvAwDASpk5KHf33Um+ekHzdUnOdPej3f31JHcmuaG2vC3Jx7r7M4vrLgAA7I15a5QPJHl86vnZSduvJXllktdV1ZuGNqyq41V1uqpOf/nLX56zGwAAsFjzXvWiBtq6u9+e5O0X27C7TyY5mSSbm5s9Zz9Yc4dOfPRbjx+77TUj9gQA2C/mnVE+m+SqqecHkzw55z4BAGB0884ofzrJtVV1TZInktyY5A2zblxVx5IcO3z48JzdALPOAMBi7eTycHckuSfJi6rqbFXd3N1PJbk1yceTPJzkA9390Kz77O5T3X18Y2Njp/0GAIBdNfOMcnfftE37XUnuWliPAABgCezKnfkAAGDVzVujPBc1yiwL9c0AwIVGDcrdfSrJqc3NzVvG7AeXZpZwOb3Odqa33WlgnWX/AACXYtSgDBcjBAMAYxKU4QLKMACARI0y+4DgCwBcCjXK7CtCMwAwK6UXrCX1zQDAvARlVs6iQrAwDQBcjKDMwu00gAqsAMAycjIf39F+DrJqmgFg/xr1Ftbdfaq7j29sbIzZDQAAeBqlFyzEfp51BgDW06gzygAAsKzMKMMuUuMMAKvLjDIAAAxw1QuY0YV12GaIAWC9ueoFAAAMUKMMC6AWGQDWj6DM07jUGwCAoAwL5x8NAFgPgjJcot0OxMo5AGBcgjJJzILuNSEYAJafoLzPCGjj8c8IAKwW11HexwS35bPdmPgHBwD23qhBubtPJTm1ubl5y5j9gDH5hwUAlpPSC1gxZpcBYG+Memc+AABYVmaU9wEf7QMA7JwZZQAAGCAoAwDAAKUXwLdxsiAAbBGUYYXtNNQKwQAwOzccgTUhBAPAYo1ao9zdp7r7+MbGxpjdAACAp1F6AfuUGWgAuDhXvQAAgAGCMgAADFB6sabcjQ8AYD5mlAEAYIAZZVhDTtQDgPmZUQYAgAFmlFecWmR2k5lpAPYzM8oAADBAUAYAgAGCMgAADBg1KFfVsao6ef78+TG7AQAATzNqUO7uU919fGNjY8xuAADA07jqBbBjroYBwH6gRhkAAAYIygAAMEDpBaw5N6UBgEtjRhkAAAaYUQbMOgPAADPKAAAwwIwyMJcLZ6NnuVycy8sBsArMKAMAwABBGQAABgjKAAAwQFAGAIABgjIAAAwQlAEAYICgDAAAA1xHeUW47iyrbru7//nbBmBZmVEGAIABCw/KVfXCqnp3VX1w0fsGAIC9MlPpRVXdnuRnkpzr7hdPtR9N8kdJLkvyZ919W3c/muRmQXl+s3xUDXtlL/7ulGEAsExmnVF+T5Kj0w1VdVmSdyS5PsmRJDdV1ZGF9g4AAEYyU1Du7ruTfPWC5uuSnOnuR7v760nuTHLDgvsHAACjmOeqFweSPD71/GySH6uq5yf53SQvrao3d/fvDW1cVceTHE+Sq6++eo5uAMtqt8s1lGoAsJvmCco10Nbd/W9J3vSdNu7uk0lOJsnm5mbP0Q8AAFi4ea56cTbJVVPPDyZ5cr7uAADAcphnRvnTSa6tqmuSPJHkxiRv2MkOqupYkmOHDx+eoxvrxRUtAACWw0wzylV1R5J7kryoqs5W1c3d/VSSW5N8PMnDST7Q3Q/t5MW7+1R3H9/Y2NhpvwEAYFfNNKPc3Tdt035XkrsW2iMAAFgCbmENAAAD5qlRnpsa5S3qkmF+LhUHwKKNOqOsRhkAgGWl9AIAAAYIygAAMECNMrBQi6q5367mWE0/AHtFjTIAAAxQegEAAAMEZQAAGCAoAwDAACfzAUtvnhP4ttvWTUkA+E6czAcAAAOUXgAAwABBGQAABgjKAAAwQFAGAIABrnoxErfhheW33W20AdgfXPUCAAAGKL0AAIABgjIAAAwQlAEAYICgDAAAAwRlAAAY4PJwAEvOZeoAxuHycAAAMEDpBQAADBCUAQBggKAMAAADBGUAABggKAMAwABBGQAABgjKAAAwQFAGAIAB7sw3h53eLWt6fWBcy3K3u+3eF9yBD2B87swHAAADlF4AAMAAQRkAAAYIygAAMEBQBgCAAYIyAAAMEJQBAGCAoAwAAAMEZQAAGCAoAwDAAEEZAAAGCMoAADDg8jFfvKqOJTl2+PDhMbuxcIdOfHTsLsC+ttNjcHr9x257zZ5tO+t+d2Ofi+wrwLoadUa5u0919/GNjY0xuwEAAE+j9AIAAAYIygAAMEBQBgCAAYIyAAAMEJQBAGCAoAwAAAMEZQAAGCAoAwDAAEEZAAAGCMoAADBAUAYAgAGCMgAADBCUAQBggKAMAAADBGUAABggKAMAwABBGQAABly+6B1W1bOT/EmSryf5ZHe/b9GvAQAAu22mGeWqur2qzlXVgxe0H62qR6rqTFWdmDT/fJIPdvctSX52wf0FAIA9MWvpxXuSHJ1uqKrLkrwjyfVJjiS5qaqOJDmY5PHJat9YTDcBAGBvzVR60d13V9WhC5qvS3Kmux9Nkqq6M8kNSc5mKyzfn4sE8ao6nuR4klx99dU77fdCHDrx0W97/thtr1nYvoD1td3xPuv7wDzvNbOYpR/brbNd36bXX+R75W7/LrZ77d3+OXd7n8tuP/7Mi7LTY3OVrOLfxTwn8x3I/88cJ1sB+UCSDyX5hap6Z5JT223c3Se7e7O7N6+88so5ugEAAIs3z8l8NdDW3f1fSX55jv0CAMDo5plRPpvkqqnnB5M8OV93AABgOcwTlD+d5NqquqaqvjvJjUk+spMdVNWxqjp5/vz5OboBAACLN+vl4e5Ick+SF1XV2aq6ubufSnJrko8neTjJB7r7oZ28eHef6u7jGxsbO+03AADsqlmvenHTNu13JblroT0CAIAl4BbWAAAwoLp7vBevOpbkWJLXJ/n8aB1ZbVck+crYnWBhjOf6MJbrxXiuF+O5XnY6nj/U3TNdm3jUoMz8qup0d2+O3Q8Ww3iuD2O5XoznejGe62U3x1PpBQAADBCUAQBggKC8+k6O3QEWyniuD2O5XoznejGe62XXxlONMgAADDCjDAAAAwTlJVRVj1XV56rq/qo6PWl7XlV9oqo+P/n6/VPrv7mqzlTVI1X101PtPzrZz5mqentV1Rg/z35TVbdX1bmqenCqbWHjV1XPrKr3T9o/VVWH9vLn22+2Gc+3VtUTk2P0/qp69dT3jOeSqqqrquofqurhqnqoqn590u74XEEXGU/H5wqqqmdV1b1V9cBkPH9n0j7u8dndliVbkjyW5IoL2n4/yYnJ4xNJ3jZ5fCTJA0memeSaJF9Ictnke/cm+fEkleRjSa4f+2fbD0uSVyR5WZIHd2P8kvxKkj+dPL4xyfvH/pnXedlmPN+a5DcH1jWeS7wkeUGSl00ePzfJP0/GzPG5gstFxtPxuYLL5Hf/nMnjZyT5VJKXj318mlFeHTckee/k8XuTvHaq/c7u/u/u/pckZ5JcV1UvSPK93X1Pb/1F/PnUNuyi7r47yVcvaF7k+E3v64NJfsqnBbtnm/HcjvFcYt39xe7+zOTx15I8nORAHJ8r6SLjuR3jucR6y39Onj5jsnRGPj4F5eXUSf62qu6rquOTth/s7i8mW28OSX5g0n4gyeNT256dtB2YPL6wnXEscvy+tU13P5XkfJLn71rP2c6tVfXZSWnGNz8KNJ4rYvKR60uzNWvl+FxxF4xn4vhcSVV1WVXdn+Rckk909+jHp6C8nH6iu1+W5Pokv1pVr7jIukP/CfVF2lkulzJ+xnZ870zyw0lekuSLSf5g0m48V0BVPSfJXyX5je7+j4utOtBmPJfMwHg6PldUd3+ju1+S5GC2ZodffJHV92Q8BeUl1N1PTr6eS/LXSa5L8qXJxwmZfD03Wf1skqumNj+Y5MlJ+8GBdsaxyPH71jZVdXmSjcxeGsACdPeXJm/o/5vkXdk6RhPjufSq6hnZClXv6+4PTZodnytqaDwdn6uvu/89ySeTHM3Ix6egvGSq6tlV9dxvPk7yqiQPJvlIkjdOVntjkg9PHn8kyY2TMzmvSXJtknsnH098rapePqm/+cWpbdh7ixy/6X29LsnfT+qw2CPffNOe+LlsHaOJ8Vxqk9/9u5M83N1/OPUtx+cK2m48HZ+rqaqurKrvmzz+niSvTPJPGfv43M0zGC2XdNbnC7N1FucDSR5K8pZJ+/OT/F2Sz0++Pm9qm7dk62zPRzJ1ZYskm9l6g/hCkj/O5AYzll0fwzuy9XHf/2Trv9ebFzl+SZ6V5C+zdeLCvUleOPbPvM7LNuP5F0k+l+SzkzfeFxjP5V+S/GS2Pmb9bJL7J8urHZ+ruVxkPB2fK7gk+ZEk/zgZtweT/PakfdTj0535AABggNILAAAYICgDAMAAQRkAAAYIygAAMEBQBgCAAYIyAAAMEJQBAGCAoAwAAAP+Dyvj62BIQKn/AAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -800,12 +891,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADICAYAAAAAypzvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANxUlEQVR4nO3dX6xlZ1kH4N9rK5hUPJE/GjIttjgNzVwJnBSNhhsNtjRj0ZDYeiGaphOjNXrhxRC84LKY6EUDSobYgIa0IP6hE0rQiKY3DTAlUNo0lQGHdCihxSYj8cJafL04u7g9zpnuM3ufs/Y53/MkK2ef76y19re7vr36m2+/a+3q7gAAwMh+YOoOAADA1IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABjenoTiqnpHVX2oqj5ZVW/bi+cAAIBVWTgUV9W9VfVMVT22rf2mqnqyqs5W1ckk6e6/6+47k/xGkl9daY8BAGDFdjNT/OEkN803VNUVST6Q5OYkx5LcXlXH5lb5w9nfAQBgbS0cirv7oSTPbWu+McnZ7v56dz+f5P4kt9aW9yX5dHd/cXXdBQCA1btyye2PJHlq7vfzSd6S5HeT/EKSjao62t0f3L5hVZ1IciJJrrrqqjffcMMNS3YFAAAu7ZFHHvlOd79me/uyobgu0tbdfU+Sey61YXefSnIqSTY3N/vMmTNLdgUAAC6tqr5xsfZl7z5xPsk1c79fneTpJfcJAAD7atlQ/IUk11fVdVX1siS3JXlg+W4BAMD+2c0t2e5L8nCSN1TV+aq6o7tfSHJXks8keSLJx7v78V3s83hVnbpw4cJu+w0AACtT3T11H9QUAwCwL6rqke7e3N7ua54BABjesnefgH1x7clPff/xubtvmbAnAMBhNOlMsZpiAADWwaShuLtPd/eJjY2NKbsBAMDg1BQDADA8NcUcODvVF6s7BgAu16ShuKqOJzl+9OjRKbvBITQfkOcJywDAxagpBgBgeMonWIlFSheUNwAA60ooZk/tVMaw0zrCMgAwBXefAABgeC6047LtNAu8yOzwMvtf1T7NSgMAL5o0FHf36SSnNzc375yyHyxuL4IqAMDU1BTz/2wPvmZUAYDDTihmrUw1E62sAgDGJhTzkpRMAACHnVA8ALOgAACX5u4TgzlsX39sFhsAWAVf8wwAwPCUT8A2yk0AYDxCMVwm4RkADg+hmEmsQy3wIn1Yh34CAHtPKIYVM4MMAAePUAwrsNOM8jIBWbgGgP0jFMPElGgAwPTcp/iQErTWj5lfAFhfk4bi7j6d5PTm5uadU/YDDipBGwBWY9Iv7wAAgHWgpviA2OsZQeUW+2u3/73NCAPA3hKKDzhhCQBgeULxAbTI7b8AAFicmmIAAIYnFAMAMDyhGACA4akphgNmmdpxF2YCwMVNOlNcVcer6tSFCxem7AYAAIObNBR39+nuPrGxsTFlNwAAGJyaYgAAhqemeI257zAAwP4QimFQe3XRnYv5ADiIlE8AADA8M8WA2V0AhicUwyGnNh0AXpryCQAAhmemeM2Y1eMgUG4BwGEjFMMh5B9XALA7yicAABiemWJgR8okABjFpKG4qo4nOX706NEpuwGHwlQlE0o1ADgMJi2f6O7T3X1iY2Njym4AADA45RPAQi5nRlj5BQAHhQvtAAAYnpliYN+ZQQZg3ZgpBgBgeEIxAADDE4oBABiemuKJqKlkNO5nDMA6M1MMAMDwzBSvATNorJN1HI8+WQFgr5kpBgBgeGaK99E6zsDBQWYGGYBVMVMMAMDwhGIAAIanfAKYlBIIANaBmWIAAIYnFAMAMDzlE3vMHScAANafmWIAAIa38pniqnp9kvck2ejud656/weB2WEAgINloZniqrq3qp6pqse2td9UVU9W1dmqOpkk3f317r5jLzoLAAB7YdHyiQ8nuWm+oaquSPKBJDcnOZbk9qo6ttLeAQDAPlgoFHf3Q0me29Z8Y5Kzs5nh55Pcn+TWFfcPAAD23DIX2h1J8tTc7+eTHKmqV1XVB5O8sarevdPGVXWiqs5U1Zlnn312iW4AAMBylrnQri7S1t39b0l+66U27u5TSU4lyebmZi/RDwAAWMoyM8Xnk1wz9/vVSZ5erjsAALD/lpkp/kKS66vquiTfTHJbkl/bzQ6q6niS40ePHl2iG+vBbdhgeQf9fTTf/3N33zJhTwDYrUVvyXZfkoeTvKGqzlfVHd39QpK7knwmyRNJPt7dj+/mybv7dHef2NjY2G2/AQBgZRaaKe7u23dofzDJgyvtEQAA7DNf8wwAwPBW/jXPu3HQa4oPev0jHES7fd+p8wVgEZPOFKspBgBgHSifAABgeEIxAADDE4oBABieC+2AYazqojsX7wEcPi60AwBgeMonAAAYnlAMAMDwhGIAAIbnQjvgUFjm4redtnVBHcA4XGgHAMDwlE8AADA8oRgAgOEJxQAADE8oBgBgeO4+sUvzV6MD49jte3/7+u5eAbDe3H0CAIDhKZ8AAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA89ynegfsRw+G203t82fsRA3AwuU8xAADDUz4BAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMb+ss7tt90/9zdt0zSD2C11v0LNeb7t8h5Z7frA7B7vrwDAIDhKZ8AAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPCunPLJq+p4kuNHjx6dshsAa+fak596yfZzd9+yX91ZykHsM/+XY8gIJp0p7u7T3X1iY2Njym4AADA45RMAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADO/KVe+wqq5K8qdJnk/yz9390VU/BwAArNJCM8VVdW9VPVNVj21rv6mqnqyqs1V1ctb8K0k+0d13JvmlFfcXAABWbtHyiQ8nuWm+oaquSPKBJDcnOZbk9qo6luTqJE/NVvvearoJAAB7Z6FQ3N0PJXluW/ONSc5299e7+/kk9ye5Ncn5bAXjhfcPAABTWqam+Ej+d0Y42QrDb0lyT5L3V9UtSU7vtHFVnUhyIkle97rXLdGN1bn25Kem7gJwSO10fplvP3f3LXv6vIvsf6f1F9nP5byWZZ5vkX3OW+b179ZeH9f94P+JrNq6vy+WCcV1kbbu7v9I8psvtXF3n0pyKkk2Nzd7iX4AAMBSlilvOJ/kmrnfr07y9HLdAQCA/bdMKP5Ckuur6rqqelmS25I8sJpuAQDA/ln0lmz3JXk4yRuq6nxV3dHdLyS5K8lnkjyR5OPd/fhunryqjlfVqQsXLuy23wAAsDIL1RR39+07tD+Y5MHLffLuPp3k9Obm5p2Xuw8AAFiWW6YBADA8oRgAgOFV9/R3Q6uqZ5N8Y+p+TOjVSb4zdSdYG8YD84wH5hkPzDMeLs9PdPdrtjeuRSgeXVWd6e7NqfvBejAemGc8MM94YJ7xsFrKJwAAGJ5QDADA8ITi9XBq6g6wVowH5hkPzDMemGc8rJCaYgAAhmemGACA4QnFe6SqzlXVV6rqS1V1Ztb2yqr6h6r66uznj86t/+6qOltVT1bVL861v3m2n7NVdU9V1RSvh92pqnur6pmqemyubWXHv6peXlUfm7V/rqqu3c/Xx+7sMB7eW1XfnJ0jvlRVb5/7m/FwiFXVNVX1T1X1RFU9XlW/N2t3jhjQJcaDc8R+627LHixJziV59ba2P0pycvb4ZJL3zR4fS/LlJC9Pcl2SryW5Yva3zyf5mSSV5NNJbp76tVkWOv5vTfKmJI/txfFP8ttJPjh7fFuSj039mi27Hg/vTfIHF1nXeDjkS5LXJnnT7PErkvzL7Lg7Rwy4XGI8OEfs82KmeH/dmuQjs8cfSfKOufb7u/s/u/tfk5xNcmNVvTbJj3T3w701kv9ibhvWWHc/lOS5bc2rPP7z+/pEkp/3KcL62mE87MR4OOS6+1vd/cXZ4+8meSLJkThHDOkS42EnxsMeEYr3Tif5+6p6pKpOzNp+vLu/lWy9CZL82Kz9SJKn5rY9P2s7Mnu8vZ2DaZXH//vbdPcLSS4kedWe9Zy9cldVPTorr3jxo3LjYSCzj7HfmORzcY4Y3rbxkDhH7CuheO/8bHe/KcnNSX6nqt56iXUv9q+1vkQ7h8vlHH9j4+D7syQ/meSnknwryR/P2o2HQVTVDyf56yS/393/fqlVL9JmTBwyFxkPzhH7TCjeI9399OznM0n+NsmNSb49+3gjs5/PzFY/n+Sauc2vTvL0rP3qi7RzMK3y+H9/m6q6MslGFv94njXQ3d/u7u91938n+VC2zhGJ8TCEqvrBbAWgj3b338yanSMGdbHx4Byx/4TiPVBVV1XVK158nORtSR5L8kCSd81We1eST84eP5DkttnVodcluT7J52cfn323qn56Vvvz63PbcPCs8vjP7+udST47qyHjgHgx/Mz8crbOEYnxcOjNjt+fJ3miu/9k7k/OEQPaaTw4R0xg6iv9DuOS5PXZujL0y0keT/KeWfurkvxjkq/Ofr5ybpv3ZOsK0iczd4eJJJvZeiN8Lcn7M/vCFct6L0nuy9bHXf+VrX+h37HK45/kh5L8VbYusPh8ktdP/Zotux4Pf5nkK0kezdb/sF5rPIyxJPm5bH10/WiSL82WtztHjLlcYjw4R+zz4hvtAAAYnvIJAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPD+B6YV6UDpoEO4AAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAMqUlEQVR4nO3dX6ik510H8O/PRCvUerDZVcIm8SSeUMiVjYegKL0RNGk4xj+9SLywSMgiNaAXXmzJTS9XQS/E2rJiaJWStNaKWRKp4h9yE5puJE0TQuy23ZJtQje1sBYvrKmPF2cSx9NzNjM7f96ZeT4feDlznp1555l9n3n3u8/83meqtRYAAOjZ9w3dAQAAGJpQDABA94RiAAC6JxQDANA9oRgAgO4JxQAAdO/aoTuQJMeOHWvb29tDdwMAgA33zDPPfLO1dvxg+0qE4u3t7Zw7d27obgAAsOGq6muHtSufAACge4OG4qraq6ozly9fHrIbAAB0btBQ3Fo721o7ubW1NWQ3AADonPIJAAC6JxQDANC9QVefqKq9JHs7OztDdoM1sH3q8TdvXzh994A9AQA2kZpiAAC6p3wCAIDurcSXd8A0jiqlUGIBAFwtNcVsPGEZAHgraooBAOie8gnmYtVmY8f7AwDwVoRiFmqSsLxqgRoA6I9QzNIIvwDAqnKhHXO3yqULgjkAcBgX2gEA0D3lE1y1Rc8Ir/KMMwCwWYRipiKoAgCbSCjmexwMvj3U3qo1BoC+CcUdWKfAZyYaABjCoBfaAQDAKrAkG2/J7C0AsOkGDcWttbNJzu7u7j4wZD96sk6lFAAAy6KmuGObEJAXMYu9CX8vAMB0hGIGsQolGZP04UoBWXgGgM0hFMOEViHIAwCLYfUJAAC6Z6YY5mCSWeRJSiyO2o/yDABYLEuywZIcVYOsLAMAhmdJtg0laAEATE75BKwxK2AAwHy40A4AgO6ZKV4Ti54RVG6xXNP+fZsRBoDFMlMMAED3zBSvIasYAADMl1C85gRhAIDZKZ8AAKB7Zophzczy6YAL9gDgcIPOFFfVXlWduXz58pDdAACgc4OG4tba2dbaya2trSG7AQBA59QUAwDQPaEYAIDuudBuhVluDQBgOYRi6NSiVqKwwgUA60goBgRZALqnphgAgO4JxQAAdE/5xIpxcR3ztogxpdwCgE1jphgAgO6ZKYYN5BMHAJiOUAwcSZkEAL1QPgEAQPcGnSmuqr0kezs7O0N2AzbCUCUTSjUA2ASDhuLW2tkkZ3d3dx8Ysh/AW7ua8Kv8AoB1oXwCAIDuudAOWDozyACsGjPFAAB0TygGAKB7QjEAAN1TUzwQNZX0xtJtAKwyM8UAAHRPKAYAoHvKJ1aAj5VZJas4HpUbAbBoZooBAOiemeIlWsUZOAAAzBQDAICZYmBYs9QLqzUGYF7MFAMA0D2hGACA7imfWDAX1wEArD4zxQAAdE8oBgCge3Mvn6iqW5I8lGSrtfa+ee9/HSiZAABYLxPNFFfVw1V1qaqeP9B+Z1W9VFXnq+pUkrTWvtJau38RnQUAgEWYtHziY0nuHG+oqmuSfDjJXUluS3JfVd02194BAMASTBSKW2tPJvnWgeY7kpwfzQx/J8mjSe6Z9Imr6mRVnauqc6+99trEHQYAgHmb5UK7E0leHvv9YpITVXVdVX00ybur6oNHPbi1dqa1ttta2z1+/PgM3QAAgNnMcqFdHdLWWmv/nuS3ZtgvAAAs1SwzxReT3Dj2+w1JXpmtOwAAsHyzzBR/PsmtVXVzkq8nuTfJr0+zg6raS7K3s7MzQzdWg2XYYHbr/j4a7/+F03cP2BMApjXpkmyPJHkqybuq6mJV3d9aez3Jg0k+m+TFJJ9qrb0wzZO31s621k5ubW1N228AAJibiWaKW2v3HdH+RJIn5tojAABYMl/zDABA9+b+Nc/TWPea4nWvf4R1NO37Tp0vAJMYdKZYTTEAAKtA+QQAAN0TigEA6J6aYqAb86ovVqcMsHnUFAMA0D3lEwAAdE8oBgCge0IxAADdE4oBAOie1SeAjTDLihBHPdYqEwD9sPoEAADdUz4BAED3hGIAALonFAMA0D2hGACA7ll9YkrjV6MD/Zj2vX/w/lavAFhtVp8AAKB7yicAAOieUAwAQPeEYgAAuicUAwDQPaEYAIDuWZLtCJZeg8121Ht81qXXAFhPlmQDAKB7yicAAOieUAwAQPeEYgAAuicUAwDQPaEYAIDuCcUAAHRPKAYAoHtCMQAA3ev6G+0OfhPVhdN3D9IPYL5W/Vvmxvs3yXln2vsDMD3faAcAQPeUTwAA0D2hGACA7gnFAAB0TygGAKB7QjEAAN0TigEA6J5QDABA94RiAAC6JxQDANA9oRgAgO4JxQAAdE8oBgCge9cO+eRVtZdkb2dnZ8huAKyc7VOPv2X7hdN3L6s7M1nHPvP/OYb0YNCZ4tba2dbaya2trSG7AQBA55RPAADQPaEYAIDuCcUAAHRPKAYAoHtCMQAA3ROKAQDonlAMAED3hGIAALonFAMA0D2hGACA7gnFAAB0TygGAKB7QjEAAN0TigEA6J5QDABA94RiAAC6JxQDANA9oRgAgO5dO+8dVtXbk/xpku8k+ZfW2ifm/RwAADBPE80UV9XDVXWpqp4/0H5nVb1UVeer6tSo+VeTfLq19kCSX5pzfwEAYO4mLZ/4WJI7xxuq6pokH05yV5LbktxXVbcluSHJy6O7fXc+3QQAgMWZqHyitfZkVW0faL4jyfnW2leSpKoeTXJPkovZD8bP5gqhu6pOJjmZJDfddNO0/V6I7VOPD90FYEMddX4Zb79w+u6FPu8k+z/q/pPs52peyyzPN8k+x83y+qe16OO6DP5NZN5W/X0xy4V2J/J/M8LJfhg+keQzSX6tqj6S5OxRD26tnWmt7bbWdo8fPz5DNwAAYDazXGhXh7S11tp/JvnNGfYLAABLNctM8cUkN479fkOSV2brDgAALN8sofjzSW6tqpur6geS3JvksWl2UFV7VXXm8uXLM3QDAABmM+mSbI8keSrJu6rqYlXd31p7PcmDST6b5MUkn2qtvTDNk7fWzrbWTm5tbU3bbwAAmJtJV5+474j2J5I8MdceAQDAkvmaZwAAulettaH7kKp6LcnXhu7HgI4l+ebQnWBlGA+MMx4YZzwwzni4Oj/eWvue9YBXIhT3rqrOtdZ2h+4Hq8F4YJzxwDjjgXHGw3wpnwAAoHtCMQAA3ROKV8OZoTvASjEeGGc8MM54YJzxMEdqigEA6J6ZYgAAuicUL0hVXaiqL1bVs1V1btT2zqr6h6r60ujnj4zd/4NVdb6qXqqqXxxr/6nRfs5X1R9XVQ3xephOVT1cVZeq6vmxtrkd/6p6W1V9ctT+uaraXubrYzpHjIcPVdXXR+eIZ6vqvWN/ZjxssKq6sar+uaperKoXqup3Ru3OER26wnhwjli21pptAVuSC0mOHWj7gySnRrdPJfn90e3bknwhyduS3Jzky0muGf3Z00l+Jkkl+bskdw392mwTHf/3JLk9yfOLOP5JPpDko6Pb9yb55NCv2Tb1ePhQkt875L7Gw4ZvSa5Pcvvo9juS/NvouDtHdLhdYTw4Ryx5M1O8XPck+fjo9seT/PJY+6Ottf9qrX01yfkkd1TV9Ul+uLX2VNsfyX8x9hhWWGvtySTfOtA8z+M/vq9PJ/l5nyKsriPGw1GMhw3XWnu1tfavo9vfTvJikhNxjujSFcbDUYyHBRGKF6cl+fuqeqaqTo7afqy19mqy/yZI8qOj9hNJXh577MVR24nR7YPtrKd5Hv83H9Naez3J5STXLaznLMqDVfXcqLzijY/KjYeOjD7GfneSz8U5onsHxkPiHLFUQvHi/Gxr7fYkdyX57ap6zxXue9j/1toV2tksV3P8jY3195EkP5HkJ5O8muQPR+3GQyeq6oeS/HWS322t/ceV7npImzGxYQ4ZD84RSyYUL0hr7ZXRz0tJ/ibJHUm+Mfp4I6Ofl0Z3v5jkxrGH35DklVH7DYe0s57mefzffExVXZtkK5N/PM8KaK19o7X23dba/yT5s+yfIxLjoQtV9f3ZD0CfaK19ZtTsHNGpw8aDc8TyCcULUFVvr6p3vHE7yS8keT7JY0neP7rb+5P87ej2Y0nuHV0denOSW5M8Pfr47NtV9dOj2p/fGHsM62eex398X+9L8k+jGjLWxBvhZ+RXsn+OSIyHjTc6fn+e5MXW2h+N/ZFzRIeOGg/OEQMY+kq/TdyS3JL9K0O/kOSFJA+N2q9L8o9JvjT6+c6xxzyU/StIX8rYChNJdrP/Rvhykj/J6AtXbKu9JXkk+x93/Xf2/4d+/zyPf5IfTPJX2b/A4ukktwz9mm1Tj4e/TPLFJM9l/x+s642HPrYkP5f9j66fS/LsaHuvc0Sf2xXGg3PEkjffaAcAQPeUTwAA0D2hGACA7gnFAAB0TygGAKB7QjEAAN0TigEA6J5QDABA94RiAAC697/SbqQDLa8ifwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -827,12 +918,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADECAYAAAB3CFyUAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOFklEQVR4nO3dbYylZ1kH8P9ly4sBXIGCIX1xi9uQbBrDy6RgNMREolvKWDQktiZKTO2GaI1+MLEEo/jBWIyaQKiaFRrQkBYExa6UAFFJY0IoLRZoU5GltulSQsHGEU20gpcf5tAc15nlzJ4zc87M/fslJ3POPc/znHv22mfnv/e5n/up7g4AAIzsO5bdAQAAWDahGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGd/5uHLSqXpvkqiTPT3Jzd3/0bNtfcMEFffjw4d3oCgAAPOmee+75Wnc/78z2mUNxVd2S5DVJHuvuy6fajyV5a5Lzkryju2/q7g8m+WBVPTvJ7yU5ayg+fPhw7r777lm7AgAA56SqHt6qfSfTJ96V5NgZBz0vyc1JrkxyNMm1VXV0apNfn3wfAABW1syhuLvvTPL4Gc1XJDnV3Q929xNJbktydW16S5IPd/enF9ddAABYvHkvtLswySNTr09P2n4pyauSvK6q3rDVjlV1vKrurqq7v/rVr87ZDQAAOHfzXmhXW7R1d78tydvOtmN3n0hyIknW1tZ6zn4AAMA5m3ek+HSSi6deX5Tk0TmPCQAAe2rekeJPJbmsqi5N8qUk1yT56Vl3rqr1JOtHjhyZsxss2+EbP/Tk84duumqJPQEA2LmdLMl2a5IfTnJBVZ1O8pvd/c6quiHJR7K5JNst3X3/rMfs7pNJTq6trV2/s26zX8wTlgVtAGCvzByKu/vabdrvSHLHwnrEUuxFABVyAYBV5TbPAAAMb1du8zwrc4r3h52O8E5vv9PjAwAsw1JDsTnFnItZQrqpGgDATiw1FDMuo8kAwCoRitkRI7AAwEEkFHPOjN4CAAeFC+0OKCO6AACzc6HdALYb0Z3lIrVVJ/wDAItgnWIAAIZnTjEHxn4a4QYAVotQPDAhEgBg01KnT1TVelWd2NjYWGY3AAAY3FJDcXef7O7jhw4dWmY3AAAYnOkTDMUtogGArQjFHHizzJ0+l/nVwjMAHByWZAMAYHhGimFGVusAgIPLbZ73IR/bL8ZuTasAAPYfq08AADA8c4oBABieUAwAwPCEYgAAhmf1iX3ORXcAAPMzUgwAwPAsyQYL4PbRALC/LTUUd/fJJCfX1tauX2Y/Dgpr6gIAnBvTJwAAGJ4L7WDBTJMAgP3HSDEAAMMzUrzCjDgCAOwNI8UAAAzPSDEs2Xarhvh0AAD2jpFiAACGJxQDADC8pYbiqlqvqhMbGxvL7AYAAINzRzvYRdvNF3b3QQBYLS60WzFCFADA3jOnGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ7VJ2CfmV6JxK2gAWAxjBQDADA8oRgAgOGZPgErapYbtphKAQCLYaQYAIDhLXWkuKrWk6wfOXJkmd2AA8GoMQCcu6WOFHf3ye4+fujQoWV2AwCAwZk+AQDA8IRiAACGJxQDADA8S7KtgFmW3oKdcNEdAOyMkWIAAIYnFAMAMDyhGACA4ZlTDMzEPGUADjIjxQAADE8oBgBgeEIxAADDE4oBABieC+3ggNvpBXIuqANgREaKAQAYnlAMAMDwTJ+AgZgaAQBbM1IMAMDwFh6Kq+qFVfXOqnr/oo8NAAC7YabpE1V1S5LXJHmsuy+faj+W5K1Jzkvyju6+qbsfTHKdULxp+uPqaT66BgBYHbOOFL8rybHphqo6L8nNSa5McjTJtVV1dKG9AwCAPTBTKO7uO5M8fkbzFUlOdfeD3f1EktuSXL3g/gEAwK6bZ/WJC5M8MvX6dJKXV9Vzk/x2kpdU1Ru7+3e22rmqjic5niSXXHLJHN3Yn7abVgHLsN3fR39PARjFPKG4tmjr7v6XJG/4djt394kkJ5JkbW2t5+gHAADMZZ7VJ04nuXjq9UVJHp2vOwAAsPfmCcWfSnJZVV1aVU9Nck2S23dygKpar6oTGxsbc3QDAADmM1Morqpbk3wiyYuq6nRVXdfd30hyQ5KPJHkgyfu6+/6dvHl3n+zu44cOHdppvwEAYGFmmlPc3ddu035HkjsW2iMAANhjbvMMAMDw5ll9Ym5VtZ5k/ciRI8vsBgxpt5Zbmz6uOzcCsF8sdaTYnGIAAFaB6RMAAAxPKAYAYHjmFC+IeZSMat65yc4dAFaBOcUAAAzP9AkAAIYnFAMAMDyhGACA4S01FFfVelWd2NjYWGY3AAAYnAvtAAAYnukTAAAMTygGAGB4QjEAAMMTigEAGJ7bPAM7Nuutnd3CGYD9wuoTAAAMz/QJAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDs07xDs2y7uqsa7gC/9d255f1jgHYbdYpBgBgeKZPAAAwPKEYAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDw3LxjBtvdjMNNOgAADgY37wAAYHimTwAAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeOcv882raj3J+pEjR5bZDWAPHL7xQ08+f+imqxZynGmzHHO7PszSvtP3AmB/WepIcXef7O7jhw4dWmY3AAAYnOkTAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPCEYgAAhicUAwAwPKEYAIDhnb/oA1bVM5L8YZInkny8u9+z6PcAAIBFmmmkuKpuqarHquq+M9qPVdXnq+pUVd04af7JJO/v7uuT/PiC+wsAAAs36/SJdyU5Nt1QVecluTnJlUmOJrm2qo4muSjJI5PNvrmYbgIAwO6ZKRR3951JHj+j+Yokp7r7we5+IsltSa5OcjqbwXjm4wMAwDJVd8+2YdXhJH/d3ZdPXr8uybHu/vnJ659J8vIkv5bk7Un+M8nfbzenuKqOJzmeJJdccsnLHn744bl+kHNx+MYPbfu9h266aqbtgNW2rHN5+n3PZrpP2+0zyzY7td2fxaKOfy792O333sv3Osj8Oe5Pq1C3VehDklTVPd29dmb7PBfa1RZt3d3/keTnvt3O3X0iyYkkWVtbmy2ZAwDALphnesPpJBdPvb4oyaPzdQcAAPbePKH4U0kuq6pLq+qpSa5JcvtiugUAAHtn1iXZbk3yiSQvqqrTVXVdd38jyQ1JPpLkgSTv6+77d/LmVbVeVSc2NjZ22m8AAFiYmeYUd/e127TfkeSOc33z7j6Z5OTa2tr153oMAACYlyXTAAAYnlAMAMDwZl6neFfevGo9yXqSn0ryhaV1ZPVckORry+4E/4+6rC61WV1qs7rUZjWpy+773u5+3pmNSw3FbK2q7t5qUWmWS11Wl9qsLrVZXWqzmtRleUyfAABgeEIxAADDE4pX04lld4AtqcvqUpvVpTarS21Wk7osiTnFAAAMz0gxAADDE4r3SFU9VFWfq6p7q+ruSdtzqupjVfWFyddnT23/xqo6VVWfr6ofm2p/2eQ4p6rqbVVVy/h59rOquqWqHquq+6baFlaLqnpaVb130v7Jqjq8lz/ffrVNXd5cVV+anDf3VtWrp76nLnukqi6uqr+rqgeq6v6q+uVJu/Nmic5SF+fNklXV06vqrqr6zKQ2vzVpd86ssu722INHkoeSXHBG2+8muXHy/MYkb5k8P5rkM0meluTSJF9Mct7ke3cl+YEkleTDSa5c9s+23x5JXpnkpUnu241aJPmFJH88eX5Nkvcu+2feD49t6vLmJL+6xbbqsre1eUGSl06ePyvJP01q4LxZzbo4b5Zfm0ryzMnzpyT5ZJJXOGdW+2GkeLmuTvLuyfN3J3ntVPtt3f1f3f3PSU4luaKqXpDku7r7E715Fvzp1D7MqLvvTPL4Gc2LrMX0sd6f5EeM6H9729RlO+qyh7r7y9396cnzryd5IMmFcd4s1Vnqsh112SO96d8nL58yeXScMytNKN47neSjVXVPVR2ftH1Pd3852fzHLcnzJ+0XJnlkat/Tk7YLJ8/PbGd+i6zFk/t09zeSbCR57q71/OC7oao+O5le8a2PGtVlSSYf0b4kmyNfzpsVcUZdEufN0lXVeVV1b5LHknysu50zK04o3js/2N0vTXJlkl+sqleeZdut/qfXZ2ln95xLLdRpcf4oyfcleXGSLyf5/Um7uixBVT0zyQeS/Ep3/9vZNt2iTX12yRZ1cd6sgO7+Zne/OMlF2Rz1vfwsm6vNChCK90h3Pzr5+liSv0xyRZKvTD4ayeTrY5PNTye5eGr3i5I8Omm/aIt25rfIWjy5T1Wdn+RQZp8WwJTu/srkF8v/JPmTbJ43ibrsuap6SjaD13u6+y8mzc6bJduqLs6b1dLd/5rk40mOxTmz0oTiPVBVz6iqZ33reZIfTXJfktuTvH6y2euT/NXk+e1JrplcWXppksuS3DX5qOXrVfWKybyhn53ah/ksshbTx3pdkr+dzAVjh771y2PiJ7J53iTqsqcmf5bvTPJAd//B1LecN0u0XV2cN8tXVc+rqu+ePP/OJK9K8o9xzqy2ZV/pN8IjyQuzeVXpZ5Lcn+RNk/bnJvmbJF+YfH3O1D5vyubVp5/P1AoTSday+Q/cF5O8PZMbsHjsqB63ZvMjxf/O5v+0r1tkLZI8PcmfZ/NCibuSvHDZP/N+eGxTlz9L8rkkn83mL4AXqMtSavND2fxY9rNJ7p08Xu28Wdm6OG+WX5vvT/IPkxrcl+Q3Ju3OmRV+uKMdAADDM30CAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMLz/BQXz2ZkiaLY3AAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADECAYAAAB3CFyUAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOCklEQVR4nO3db6zkV1kH8O9jyx8DeAW6GLJt3eI2JA0x/Nk0EA0xkUhLvYJKYusLiWnYEK3RF74owSi+K0ZNJFbIKg1oSAsiahdKgKiEN4TSYoHWWinYpksJBdEr+kIEH1/caR2Xe5e5O3Nn5t7z+SSTO3Pub35z7p49e7975pnzq+4OAACM7HtW3QEAAFg1oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPCEYgAAhnfhfpy0ql6T5Jokz0lyc3d/5FzHX3TRRX3s2LH96AoAADzh7rvv/lp3Hzm7feZQXFW3JPnJJI919wum2q9K8gdJLkjyJ919U3f/VZK/qqpnJvndJOcMxceOHctdd901a1cAAOC8VNXDO7XvpXzinUmuOuukFyS5OcnVSa5Icl1VXTF1yG9Mvg8AAGtr5lDc3R9P8vWzmq9M8mB3f7G7v5nktiSvrm1vSfKh7v70TuerqpNVdVdV3fXVr371fPsPAABzm/eDdkeTPDL1+Myk7VeSvCLJa6vqDTs9sbtPdfeJ7j5x5Mh3lHUAAMDSzPtBu9qhrbv7rUneOue5AQBgKeZdKT6T5JKpxxcneXTOcwIAwFLNu1L8qSSXV9VlSb6U5NokPz/rk6tqM8nm8ePH5+wGq3bsxg8+cf+hm65ZYU8AAPZuL1uy3Zrkx5JcVFVnkvxWd7+jqm5I8uFsb8l2S3ffN+s5u/t0ktMnTpx4/d66zUExT1gWtAGAZZk5FHf3dbu035HkjoX1iENLyAUA1tW+XNGOw0WYBQAOu5WGYjXF62ORwXf6XPt9vJAOACzCSkOxmmJmJTgDAPtp3i3ZAADgwFNTzJ4sagV2ryu/AAD7SU3xIbWM8gHBFgA4LFZaPtHdp7v75MbGxiq7AQDA4NQUAwAwPDXFA9itzGG3soqDVBZhlwkAYBGEYg6NgxTmAYD1stLyiararKpTW1tbq+wGAACDc/GOgVlZBQDYpnwCzqJOGQDGIxQzlN0C7/msmgvPAHB4CMUcespEAIDvxj7FAAAMz2WeDyBv26+GFWcAOLzsPgHnIAgDwBjUFDMsgRcAeJyaYgAAhicUAwAwPKEYAIDhqSk+4OxEAQAwPyvFAAAMzz7FsACzrNhb1QeA9WWf4kPEFmMAAOdHTTEsmBVhADh41BQDADA8oRgAgOEpn1hj3oYHAFgOK8UAAAzPSjGs2G67hnh3AACWx0oxAADDW2korqrNqjq1tbW1ym4AADA4F++AfeSCKgBwMKgpXjO7hSjh6nAxngCwXtQUAwAwPKEYAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYni3Z4ICZ3s7NpaABYDGsFAMAMDyhGACA4SmfgDU1y1XvlFIAwGKsNBRX1WaSzePHj6+yG3AoCMgAcP5WWj7R3ae7++TGxsYquwEAwODUFAMAMDyhGACA4QnFAAAMTygGAGB4tmRbA7NsvQV7YScKANgbK8UAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDw7D4BzMSOFgAcZlaKAQAYnlAMAMDwlE/AIbfXsgdlEgCMyEoxAADDs1IMA7EKDAA7s1IMAMDwhGIAAIa38PKJqnpekjcl2eju1y76/AfN9NvV07x1DQCwPmZaKa6qW6rqsaq696z2q6rqgap6sKpuTJLu/mJ3X78fnQUAgP0wa/nEO5NcNd1QVRckuTnJ1UmuSHJdVV2x0N4BAMASzFQ+0d0fr6pjZzVfmeTB7v5iklTVbUleneQfZjlnVZ1McjJJLr300hm7e3jsVlYBq7Db30d/TwEYxTwftDua5JGpx2eSHK2qZ1fV25O8qKreuNuTu/tUd5/o7hNHjhyZoxsAADCfeT5oVzu0dXf/S5I3zHFeAABYqnlWis8kuWTq8cVJHp2vOwAAsHzzhOJPJbm8qi6rqicnuTbJ7Xs5QVVtVtWpra2tOboBAADzmXVLtluTfCLJ86vqTFVd393fSnJDkg8nuT/Je7v7vr28eHef7u6TGxsbe+03AAAszKy7T1y3S/sdSe5YaI8AAGDJXOYZAIDhLfwyz3tRVZtJNo8fP77KbsCQ9msP4unzupw5AAfFSleK1RQDALAOlE8AADA8oRgAgOGpKV4QdZSMat7aZHMHgHWgphgAgOEpnwAAYHhCMQAAwxOKAQAY3kpDcVVtVtWpra2tVXYDAIDB+aAdAADDUz4BAMDwhGIAAIYnFAMAMDyhGACA4bnMM7Bns17a2SWcATgo7D4BAMDwlE8AADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABiefYr3aJZ9V2fdwxX4/3abX/Y7BmC/2acYAIDhKZ8AAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOG5eMcMdrsYh4t0AAAcDi7eAQDA8JRPAAAwPKEYAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAM78JVvnhVbSbZPH78+Cq7ASzBsRs/+MT9h266ZiHnmTbLOXfrwyzte30tAA6Wla4Ud/fp7j65sbGxym4AADA45RMAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeBcu+oRV9bQkf5Tkm0k+1t3vXvRrAADAIs20UlxVt1TVY1V171ntV1XVA1X1YFXdOGn+mSTv6+7XJ/mpBfcXAAAWbtbyiXcmuWq6oaouSHJzkquTXJHkuqq6IsnFSR6ZHPbtxXQTAAD2T3X3bAdWHUvyge5+weTxy5K8ubtfOXn8xsmhZ5L8a3d/oKpu6+5rdznfySQnk+TSSy99ycMPPzzPz3Fejt34wV2/99BN18x0HLDeVjWXp1/3XKb7tNtzZjlmr3b7s1jU+c+nH/v92st8rcPMn+PBtA7jtg59SJKquru7T5zdPs8H7Y7m/1aEk+0wfDTJ+5P8bFW9Lcnp3Z7c3ae6+0R3nzhy5Mgc3QAAgPnM80G72qGtu/s/k/ziHOcFAIClmmel+EySS6YeX5zk0fm6AwAAyzdPKP5Uksur6rKqenKSa5PcvpcTVNVmVZ3a2tqaoxsAADCfWbdkuzXJJ5I8v6rOVNX13f2tJDck+XCS+5O8t7vv28uLd/fp7j65sbGx134DAMDCzFRT3N3X7dJ+R5I7FtojAABYMpd5BgBgeDPvU7wvL161mWQzyc8l+fzKOrJ+LkrytVV3gu9gXNaXsVlfxmZ9GZv1ZFz23w9293fsB7zSUMzOququnTaVZrWMy/oyNuvL2KwvY7OejMvqKJ8AAGB4QjEAAMMTitfTqVV3gB0Zl/VlbNaXsVlfxmY9GZcVUVMMAMDwrBQDADA8oRgAgOEJxUtSVQ9V1eeq6p6qumvS9qyq+mhVfX7y9ZlTx7+xqh6sqgeq6pVT7S+ZnOfBqnprVdUqfp6DrKpuqarHqureqbaFjUVVPaWq3jNp/2RVHVvmz3dQ7TIub66qL03mzT1V9aqp7xmXJamqS6rq76rq/qq6r6p+ddJu3qzQOcbFvFmxqnpqVd1ZVZ+ZjM1vT9rNmXXW3W5LuCV5KMlFZ7X9TpIbJ/dvTPKWyf0rknwmyVOSXJbkC0kumHzvziQvS1JJPpTk6lX/bAftluTlSV6c5N79GIskv5Tk7ZP71yZ5z6p/5oNw22Vc3pzk13c41rgsd2yem+TFk/vPSPJPkzEwb9ZzXMyb1Y9NJXn65P6TknwyyUvNmfW+WSlerVcnedfk/ruSvGaq/bbu/q/u/uckDya5sqqem+T7uvsTvT0L/nTqOcyouz+e5OtnNS9yLKbP9b4kP25F/7vbZVx2Y1yWqLu/3N2fntz/RpL7kxyNebNS5xiX3RiXJelt/zF5+KTJrWPOrDWheHk6yUeq6u6qOjlp+4Hu/nKy/Y9bkudM2o8meWTquWcmbUcn989uZ36LHIsnntPd30qyleTZ+9bzw++GqvrspLzi8bcajcuKTN6ifVG2V77MmzVx1rgk5s3KVdUFVXVPkseSfLS7zZk1JxQvz49094uTXJ3kl6vq5ec4dqf/6fU52tk/5zMWxmlx3pbkh5K8MMmXk/zepN24rEBVPT3JXyT5te7+93MdukOb8dknO4yLebMGuvvb3f3CJBdne9X3Bec43NisAaF4Sbr70cnXx5L8ZZIrk3xl8tZIJl8fmxx+JsklU0+/OMmjk/aLd2hnfosciyeeU1UXJtnI7GUBTOnur0x+sfxPkj/O9rxJjMvSVdWTsh283t3d7580mzcrttO4mDfrpbv/LcnHklwVc2atCcVLUFVPq6pnPH4/yU8kuTfJ7UleNznsdUn+enL/9iTXTj5ZelmSy5PcOXmr5RtV9dJJ3dAvTD2H+SxyLKbP9dokfzupBWOPHv/lMfHT2Z43iXFZqsmf5TuS3N/dvz/1LfNmhXYbF/Nm9arqSFV9/+T+9yZ5RZJ/jDmz3lb9Sb8Rbkmel+1PlX4myX1J3jRpf3aSv0ny+cnXZ009503Z/vTpA5naYSLJiWz/A/eFJH+YyVUJ3fY0Hrdm+y3F/872/7SvX+RYJHlqkj/P9gcl7kzyvFX/zAfhtsu4/FmSzyX5bLZ/ATzXuKxkbH4022/LfjbJPZPbq8ybtR0X82b1Y/PDSf5+Mgb3JvnNSbs5s8Y3l3kGAGB4yicAABieUAwAwPCEYgAAhicUAwAwPKEYAIDhCcUAAAxPKAYAYHj/C4Ar1u2+16MjAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -854,12 +945,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOBElEQVR4nO3db4zlV1kH8O9ji2AAR6HVkP5xi9uQbIjhz6ZCNMREAi11BZWElheiadgQrdEXvliCUXxhXE00kYiYRRrQkBZEEJaWIFEJbwilxQJtaqXgNl1KWBBd0Rci+PhibstlmdnO7L0zvztzPp/kZu4987v3njvPnpnvnnvu+VV3BwAARvY9U3cAAACmJhQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDu3jqDiTJJZdc0gcOHJi6GwAA7HN33333V7v70nPbVyIUHzhwIHfdddfU3QAAYJ+rqoc2ard8AgCA4QnFAAAMb0dCcVW9oqreWlXvr6qX7MRzAADAsmw5FFfVLVV1pqruPaf92qp6oKoerKpjSdLdf9vdr03yS0letdQeAwDAkm1npvjtSa6db6iqi5K8Ocl1SQ4lubGqDs0d8luz7wMAwMra8u4T3f2xqjpwTvM1SR7s7i8kSVXdluTlVXV/kuNJPtTdn1pSXxnYgWO3P3b91PHrJ+wJALAfLbqm+LIkD8/dPj1r+7UkL07yyqp63UZ3rKqjVXVXVd31la98ZcFuAADAhVt0n+LaoK27+01J3nS+O3b3iSQnkuTw4cO9YD8AAOCCLRqKTye5Yu725UkeWfAx4bwspQAAlm3RUPzJJFdX1VVJvpjkhiSv3uqdq+pIkiMHDx5csBvsR/PhFwBgJ205FFfVrUl+KsklVXU6ye9099uq6uYkH05yUZJbuvu+rT5md59McvLw4cOv3V63WTWrMHu7lRBtZhkA2Mh2dp+4cZP2O5LcsbQesedtNyDvZqBehfAOAKwep3kGAGB4i64pXog1xWPZyiytdcQAwBQmDcXWFLMoIRoAWIZJQzGsIuuOAWA8QjE7ykwuALAXWFPMBVsk8K5CWDYjDAA8yppiyGqEdABgOrZkAwBgeEIxAADDE4oBABjepKG4qo5U1YmzZ89O2Q0AAAbng3Z8l3M/dDa/M4MPpH3bVn4WdrUAgL3B8gkAAIbn5B08LrPDAMB+JxQPzMkrtudC/nPgZwwAe4PlEwAADM/uEwAADG/SUNzdJ7v76Nra2pTdAABgcJZPAAAwPB+0g/Ow8wYAjEEohglsZVcKO1cAwO4RimGXmHUGgNUlFJNEYJvSdmeEzSADwPLZkg0AgOHZkg0AgOHZkg0AgOEJxQAADE8oBgBgeEIxAADDsyUbrBBb4wHANMwUAwAwPDPFgzETub84kQcALIeTdwAAMDwn7wAAYHjWFAMAMDxrimEPsBYcAHaWUAz7hA/dAcCFE4oHYJYRAOD8rCkGAGB4QjEAAMOzfAL2IeuLAWB7hOJ9yjpiHrVZQBacAeDbLJ8AAGB4QjEAAMMTigEAGN6kobiqjlTVibNnz07ZDQAABjdpKO7uk919dG1tbcpuAAAwOLtP7CN2nAAAuDDWFAMAMDwzxTAQ7yYAwMbMFAMAMDyhGACA4QnFAAAMz5pi4DvWGp86fv2+ez4AeDxmigEAGJ6ZYuA7bLZDhRldAPYzM8UAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIZnS7Y9yIkPAACWy0wxAADDW3oorqpnVtXbquo9y35sAADYCVtaPlFVtyT5mSRnuvvZc+3XJvmTJBcl+YvuPt7dX0hyk1C8XJudZWyzdpiKM+IBsBdtdab47UmunW+oqouSvDnJdUkOJbmxqg4ttXcAALALthSKu/tjSb52TvM1SR7s7i909zeS3Jbk5UvuHwAA7LhFdp+4LMnDc7dPJ/nxqnp6kt9L8tyqen13//5Gd66qo0mOJsmVV165QDeA3bDorieW+gCwyhYJxbVBW3f3vyV53ePdubtPJDmRJIcPH+4F+gEAAAtZZPeJ00mumLt9eZJHFusOAADsvkVmij+Z5OqquirJF5PckOTV23mAqjqS5MjBgwcX6Mb+5e1mVtVO/dt0YhoAprKlmeKqujXJx5M8q6pOV9VN3f3NJDcn+XCS+5O8u7vv286Td/fJ7j66tra23X4DAMDSbGmmuLtv3KT9jiR3LLVHAACwy5zmGQCA4S2ypnhh1hQD1s4DsAomnSm2phgAgFVg+QQAAMMTigEAGN6kobiqjlTVibNnz07ZDQAABmdNMQAAw7N8AgCA4QnFAAAMTygGAGB4Tt4BrKT5k3qcOn79hD0BYAQ+aAcAwPAsnwAAYHhCMQAAwxOKAQAYnlAMAMDwnOYZAIDh2X0CAIDhWT4BAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAM7+Ipn7yqjiQ5cvDgwSm7MbkDx25/7Pqp49dP2BNg3mZjcytjdv6Y8x0HwGqwJRsAAMOzfAIAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPCEYgAAhufkHRM5d2P/x2uHkW1lXDg5BgCLcPIOAACGZ/kEAADDE4oBABieUAwAwPCEYgAAhicUAwAwPKEYAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwLp7yyavqSJIjBw8enLIbS3fg2O2PXT91/PoJewJsZTwua8zOPw4Ae8ukM8XdfbK7j66trU3ZDQAABmf5BAAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDu3jZD1hVT07yZ0m+keSj3f3OZT8HAAAs05Zmiqvqlqo6U1X3ntN+bVU9UFUPVtWxWfPPJ3lPd782yc8uub8AALB0W10+8fYk1843VNVFSd6c5Lokh5LcWFWHklye5OHZYd9aTjcBAGDnVHdv7cCqA0k+2N3Pnt1+YZI3dvdLZ7dfPzv0dJJ/7+4PVtVt3X3DJo93NMnRJLnyyiuf/9BDDy3yOi7IgWO3f8ftU8evX9pjAattfrzv9vjdyu+azfq02X3nj9/Ka1vk9x2rZ7P6r4JV7htbs6warsq/haq6u7sPn9u+yAftLsu3Z4ST9TB8WZL3JvmFqnpLkpOb3bm7T3T34e4+fOmlly7QDQAAWMwiH7SrDdq6u/87yS8v8LgAALCrFpkpPp3kirnblyd5ZLHuAADA7lskFH8yydVVdVVVfW+SG5J8YDsPUFVHqurE2bNnF+gGAAAsZqtbst2a5ONJnlVVp6vqpu7+ZpKbk3w4yf1J3t3d923nybv7ZHcfXVtb226/AQBgaba0pri7b9yk/Y4kdyy1RwAAsMuc5hkAgOFteZ/iHXnyqiNJjiR5VZLPTdaR/emSJF+duhNsSG1Wk7qsJnVZXWqzmtTl8f1Id3/XfsCThmJ2TlXdtdHG1ExPbVaTuqwmdVldarOa1OXCWT4BAMDwhGIAAIYnFO9fJ6buAJtSm9WkLqtJXVaX2qwmdblA1hQDADA8M8UAAAxPKN5DqupUVX22qu6pqrtmbU+rqo9U1edmX39w7vjXV9WDVfVAVb10rv35s8d5sKreVFU1xevZy6rqlqo6U1X3zrUtrRZV9cSqetes/RNVdWA3X99etUld3lhVX5yNm3uq6mVz31OXXVBVV1TVP1bV/VV1X1X9+qzdmJnYeWpj3Eyoqp5UVXdW1adndfndWbsxs5O622WPXJKcSnLJOW1/mOTY7PqxJH8wu34oyaeTPDHJVUk+n+Si2ffuTPLCJJXkQ0mum/q17bVLkhcleV6Se3eiFkl+Jcmfz67fkORdU7/mvXDZpC5vTPKbGxyrLrtXl2cked7s+lOT/Mvs52/MrG5tjJtp61JJnjK7/oQkn0jyAmNmZy9mive+lyd5x+z6O5K8Yq79tu7+n+7+1yQPJrmmqp6R5Pu7++O9PhL+cu4+bFF3fyzJ185pXmYt5h/rPUl+2oz+49ukLptRl13S3V/q7k/Nrn89yf1JLosxM7nz1GYzarMLet1/zW4+YXbpGDM7SijeWzrJ31XV3VV1dNb2w939pWT9l1uSH5q1X5bk4bn7np61XTa7fm47i1tmLR67T3d/M8nZJE/fsZ7vfzdX1WdmyysefbtRXSYwe4v2uVmf+TJmVsg5tUmMm0lV1UVVdU+SM0k+0t3GzA4TiveWn+ju5yW5LsmvVtWLznPsRv/b6/O0s3MupBbqtDxvSfKjSZ6T5EtJ/mjWri67rKqekuRvkvxGd//n+Q7doE1tdtAGtTFuJtbd3+ru5yS5POuzvs8+z+HqsgRC8R7S3Y/Mvp5J8r4k1yT58uztkcy+npkdfjrJFXN3vzzJI7P2yzdoZ3HLrMVj96mqi5OsZevLApjT3V+e/XH5vyRvzfq4SdRlV1XVE7Ieut7Z3e+dNRszK2Cj2hg3q6O7/yPJR5NcG2NmRwnFe0RVPbmqnvro9SQvSXJvkg8kec3ssNckef/s+geS3DD7dOlVSa5Ocufs7ZavV9ULZmuHfnHuPixmmbWYf6xXJvmH2XowtunRPyAzP5f1cZOoy66Z/RzfluT+7v7juW8ZMxPbrDbGzbSq6tKq+oHZ9e9L8uIk/xxjZmdN/Uk/l61dkjwz658s/XSS+5K8Ydb+9CR/n+Rzs69Pm7vPG7L+CdQHMrfDRJLDWf8F9/kkf5rZSVxctlWPW7P+luL/Zv1/2zctsxZJnpTkr7P+YYk7kzxz6te8Fy6b1OWvknw2yWey/kfgGeqy63X5yay/LfuZJPfMLi8zZqa/nKc2xs20dfmxJP80+/nfm+S3Z+3GzA5enNEOAIDhWT4BAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGN7/AwHTyRcyHnRDAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAON0lEQVR4nO3dX4xtV10H8O/PFsEAjkKrIf3jLd6GpCGGPzcFouFFAi11BP8ktDyIpumN0Rp98OESjMEHYzHRRCJCLtKAhrQgonBpCRKV8NJQWizQplYK3qaXEgqiI/ogFn8+zGk5XGZu595zZvaZWZ9PsjP7rNl7n3Vm3TXzveusvU51dwAAYGTfN3UFAABgakIxAADDE4oBABieUAwAwPCEYgAAhicUAwAwvPOnrkCSXHDBBX3o0KGpqwEAwAF39913f727Lzy9fCVC8aFDh3LXXXdNXQ0AAA64qnpoq3LTJwAAGN6uhOKqem1VvbOqPlRVr9yN5wAAgGXZcSiuqpur6tGquve08quq6oGqerCqjiVJd/9td9+Q5JeTvG6pNQYAgCU7m5Hidye5ar6gqs5L8rYkVye5Isl1VXXF3CG/M/s+AACsrB2H4u7+ZJJvnFZ8ZZIHu/tL3f2tJLcmeU1tekuSj3b3Z7a6XlUdraq7ququr33ta+dafwAAWNiiq09clOThucenkrwkyW8keUWStao63N3vOP3E7j6e5HiSHDlypBesBwfcoWO3PbF/8qZrJqwJAHAQLRqKa4uy7u63JnnrgtcGAIA9sWgoPpXkkrnHFyd5ZMFrwhkZNQYAlm3RUPzpJJdX1WVJvpzk2iSv3+nJVbWeZP3w4cMLVoODaD78AgDsprNZku2WJHckeV5Vnaqq67v7sSQ3JvlYkvuTvL+779vpNbv7RHcfXVtbO9t6w44dOnbbExsAwFZ2PFLc3ddtU357ktuXViOGs6zpEDsJvaZeAABbWXT6BCTZWdgUSAGAVTVpKDan+GASfgGA/WbSUNzdJ5KcOHLkyA1T1oPVYd4vADAF0yfY13YjRBvpBoDx7Hj1CQAAOKjMKWZXrfJ0CCPCAMDjzClmEqsWlletPgDA3jKnmHMmSAIAB4U5xQAADE8oBgBgeJOG4qpar6rjGxsbU1YDAIDBudEOlmC7+dVWtQCA/cGNdnyP0wPefLBzc913+FkAwMEhFPOkhL9zZy1kANgfhOKBCWwAAJuEYtghI+YAcHBZfQIAgOFNGoq7+0R3H11bW5uyGgAADM6HdwAAMDxziuEMzCMGgDEIxTCBnaz8YXUQANg7pk8AADA8I8WwR0zFAIDVNWkorqr1JOuHDx+eshpEYJvS2U6TMK0CAJbPkmwAAAzPnGIAAIYnFAMAMDyhGACA4QnFAAAMz5JssEKsAgIA0zBSDADA8IwUD8ZI5MFizWIAWI5JR4qrar2qjm9sbExZDQAABufDOwAAGJ45xQAADM+cYtgHzAUHgN0lFMMB4aY7ADh3QvEAjDICAJyZOcUAAAxPKAYAYHimT8ABZH4xAJwdofiAMo+Yx20XkAVnAPgO0ycAABieUAwAwPCEYgAAhicUAwAwvElDcVWtV9XxjY2NKasBAMDgJl19ortPJDlx5MiRG6asx0FhxQkAgHNj+gQAAMOzTjEMxLsJALA1I8UAAAxPKAYAYHhCMQAAwzOnGPiuucYnb7rmwD0fADwZI8UAAAzPSDHwXbZbocKILgAHmZFiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDsyTbPuSDDwAAlstIMQAAw1t6KK6q51bVu6rqA8u+NgAA7IYdTZ+oqpuT/EySR7v7+XPlVyX5kyTnJfnz7r6pu7+U5HqheLm2+5Sx7cphKj4RD4D9aKcjxe9OctV8QVWdl+RtSa5OckWS66rqiqXWDgAA9sCOQnF3fzLJN04rvjLJg939pe7+VpJbk7xmyfUDAIBdt8jqExcleXju8akkL6mqZyf5/SQvrKo3dvcfbHVyVR1NcjRJLr300gWqAeyFRVc9MdUHgFW2SCiuLcq6u/8tya8+2cndfTzJ8SQ5cuRIL1APAABYyCKrT5xKcsnc44uTPLJYdQAAYO8tMlL86SSXV9VlSb6c5Nokrz+bC1TVepL1w4cPL1CNg8vbzayq3fq36YNpAJjKjkaKq+qWJHckeV5Vnaqq67v7sSQ3JvlYkvuTvL+77zubJ+/uE919dG1t7WzrDQAAS7OjkeLuvm6b8tuT3L7UGgEAwB7zMc8AAAxv0lBcVetVdXxjY2PKagAAMLhJQ7E5xQAArALTJwAAGJ5QDADA8BZZp3hh1ikGrMcNwCowpxgAgOGZPgEAwPCEYgAAhicUAwAwPDfaAStp/ga8kzddM2FNABiBG+0AABie6RMAAAxPKAYAYHhCMQAAwxOKAQAY3qShuKrWq+r4xsbGlNUAAGBwVp8AAGB4pk8AADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABje+VM+eVWtJ1k/fPjwlNWY3KFjtz2xf/KmayasCTBvu765kz47f8yZjgNgNVinGACA4Zk+AQDA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADD8+EdEzl9Yf8nK4eR7aRf+HAMABbhwzsAABie6RMAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMM7f8onr6r1JOuHDx+eshpLd+jYbU/sn7zpmglrAuykPy6rz85fB4D9ZdKR4u4+0d1H19bWpqwGAACDM30CAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOGdv+wLVtXTk/xZkm8l+UR3v3fZzwEAAMu0o5Hiqrq5qh6tqntPK7+qqh6oqger6tis+OeTfKC7b0jys0uuLwAALN1Op0+8O8lV8wVVdV6StyW5OskVSa6rqiuSXJzk4dlh315ONQEAYPdUd+/swKpDST7S3c+fPX5Zkjd396tmj984O/RUkn/v7o9U1a3dfe021zua5GiSXHrppS9+6KGHFnkd5+TQsdu+6/HJm65Z2rWA1Tbf3/e6/+7kd812ddru3Pnjd/LaFvl9x+rZrv1XwSrXjZ1ZVhuuyr+Fqrq7u4+cXr7IjXYX5TsjwslmGL4oyQeT/EJVvT3Jie1O7u7j3X2ku49ceOGFC1QDAAAWs8iNdrVFWXf3fyf5lQWuCwAAe2qRkeJTSS6Ze3xxkkcWqw4AAOy9RULxp5NcXlWXVdX3J7k2yYfP5gJVtV5Vxzc2NhaoBgAALGanS7LdkuSOJM+rqlNVdX13P5bkxiQfS3J/kvd3931n8+TdfaK7j66trZ1tvQEAYGl2NKe4u6/bpvz2JLcvtUYAALDHfMwzAADD2/E6xbvy5FXrSdaTvC7JFyaryMF0QZKvT10JtqRtVpN2WU3aZXVpm9WkXZ7cj3X396wHPGkoZvdU1V1bLUzN9LTNatIuq0m7rC5ts5q0y7kzfQIAgOEJxQAADE8oPriOT10BtqVtVpN2WU3aZXVpm9WkXc6ROcUAAAzPSDEAAMMTiveRqjpZVZ+vqnuq6q5Z2bOq6uNV9YXZ1x+eO/6NVfVgVT1QVa+aK3/x7DoPVtVbq6qmeD37WVXdXFWPVtW9c2VLa4uqempVvW9W/qmqOrSXr2+/2qZd3lxVX571m3uq6tVz39Mue6CqLqmqf6yq+6vqvqr6zVm5PjOxM7SNfjOhqnpaVd1ZVZ+dtcvvzcr1md3U3bZ9siU5meSC08r+MMmx2f6xJG+Z7V+R5LNJnprksiRfTHLe7Ht3JnlZkkry0SRXT/3a9tuW5OVJXpTk3t1oiyS/luQds/1rk7xv6te8H7Zt2uXNSX57i2O1y961y3OSvGi2/8wk/zL7+eszq9s2+s207VJJnjHbf0qSTyV5qT6zu5uR4v3vNUneM9t/T5LXzpXf2t3/093/muTBJFdW1XOS/GB339GbPeEv5s5hh7r7k0m+cVrxMtti/lofSPLTRvSf3Dbtsh3tske6+yvd/ZnZ/jeT3J/kougzkztD22xH2+yB3vRfs4dPmW0dfWZXCcX7Syf5u6q6u6qOzsp+tLu/kmz+ckvyI7Pyi5I8PHfuqVnZRbP908tZ3DLb4olzuvuxJBtJnr1rNT/4bqyqz82mVzz+dqN2mcDsLdoXZnPkS59ZIae1TaLfTKqqzquqe5I8muTj3a3P7DKheH/5ye5+UZKrk/x6Vb38DMdu9b+9PkM5u+dc2kI7Lc/bk/x4khck+UqSP5qVa5c9VlXPSPLXSX6ru//zTIduUaZtdtEWbaPfTKy7v93dL0hycTZHfZ9/hsO1yxIIxftIdz8y+/pokr9JcmWSr87eHsns66Ozw08luWTu9IuTPDIrv3iLcha3zLZ44pyqOj/JWnY+LYA53f3V2R+X/0vyzmz2m0S77Kmqeko2Q9d7u/uDs2J9ZgVs1Tb6zero7v9I8okkV0Wf2VVC8T5RVU+vqmc+vp/klUnuTfLhJG+YHfaGJB+a7X84ybWzu0svS3J5kjtnb7d8s6peOps79Etz57CYZbbF/LV+Mck/zOaDcZYe/wMy83PZ7DeJdtkzs5/ju5Lc391/PPctfWZi27WNfjOtqrqwqn5otv8DSV6R5J+jz+yuqe/0s+1sS/LcbN5Z+tkk9yV506z82Un+PskXZl+fNXfOm7J5B+oDmVthIsmRbP6C+2KSP83sQ1xsZ9Uet2TzLcX/zeb/tq9fZlskeVqSv8rmzRJ3Jnnu1K95P2zbtMtfJvl8ks9l84/Ac7TLnrfLT2XzbdnPJblntr1an5l+O0Pb6DfTtstPJPmn2c//3iS/OyvXZ3Zx84l2AAAMz/QJAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDE4oBABieUAwAwPD+HxHf0rdgyxsrAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -883,17 +974,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The raw value column has very complex distribution.  When grouped by start-year, three distinct patterns emerge.  1. declining seen 2009, 2010 and 2011, 2. double peaks seen in 2008, 2006, 2007, 2004, 2005, 2003 and 2002, 3. one peak seen in 1997, 1998, 2001, 2000 and 1999.  Although 2012 also has only one peak, the raw_values are very different from other years since they are all less than 1.  Therefore, data will be analyzed in four groups.  "
+    "The raw value column has very complex distribution.  When grouped by start-year, three distinct patterns emerge.  1. declining seen 2009, 2010 and 2011, 2. double peaks seen in 2008, 2006, 2007, 2004, 2005, 2003 and 2002, 3. one peak seen in 1997, 1998, 2001, 2000 and 1999.  Although 2012 also has only one peak, the raw_values are very different from other years since they are all less than 1.  Therefore, data will be analyzed in four groups.  \n",
+    "\n",
+    "### <b>Group by similar years"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADGCAYAAAA6wP2fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAARa0lEQVR4nO3df4xld1nH8ffHrVNNwfFHCyG7O87ibho3/AF00qokpH+AbIVxEVF3IQqm6Qhhjf5h4qIm8I+xmkgioUJW2RQS7GaDRXfSxWKMpJo0ui2pstu1OK7FDtuwRcyKxtgsPP4xt+11mJneO+fOnHvnvF/Jzd7znXPPee4+e9on33nO96SqkCRJkrrsO9oOQJIkSWqbRbEkSZI6z6JYkiRJnWdRLEmSpM6zKJYkSVLnWRRLkiSp8yyKJUmS1HkWxZIkSeq8kRfFSW5P8jdJPpbk9lEfX5IkSRq1gYriJCeTXElyftX4oSRPJFlKcrw3XMB/Ad8FLI82XEmSJGn0MshjnpO8npVC95NV9are2C7gS8AbWSl+zwFHgX+qqm8leTnwoap654sd/8Ybb6zZ2dlNfwlJkiRpEI8++ujXquqm1ePXDfLhqnooyeyq4VuBpaq6BJDkFHC4qh7v/fw/gOsHOf7s7CyPPPLIILtKkiRJm5bky2uND1QUr2M38FTf9jJwW5K3AW8Cvhf4yAYBLQALADMzMw3CkCRJkpppUhRnjbGqqvuB+1/sw1V1IsnTwPzU1NQtDeKQJEmSGmmy+sQysLdvew9weZgDVNViVS1MT083CEOSJElqpklRfA44kGRfkingCHBmmAMkmU9y4urVqw3CkCRJkpoZdEm2+4CHgZuTLCe5s6quAceAB4GLwOmqurB1oUqSJElbY6Al2bba3NxctbH6xOzxB/7f9pN3v3nbY5AkSdL2SfJoVc2tHm/1Mc+2T0iSJGkctFoUe6OdJEmSxkGrRbEkSZI0DmyfkCRJUufZPiFJkqTOs31CkiRJnWf7hCRJkjrP9glJkiR1nu0TkiRJ6jyLYkmSJHWePcWSJEnqPHuKJUmS1Hm2T0iSJKnzLIolSZLUeRbFkiRJ6jxvtJMkSVLneaOdJEmSOs/2CUmSJHWeRbEkSZI6z6JYkiRJnWdRLEmSpM7bkqI4yQ1JHk3ylq04viRJkjRKAxXFSU4muZLk/KrxQ0meSLKU5Hjfj34dOD3KQCVJkqStMuhM8b3Aof6BJLuAe4A7gIPA0SQHk7wBeBz46gjjlCRJkrbMdYPsVFUPJZldNXwrsFRVlwCSnAIOAy8BbmClUP6fJGer6lurj5lkAVgAmJmZ2Wz8kiRJUmMDFcXr2A081be9DNxWVccAkrwb+NpaBTFAVZ0ATgDMzc1VgzgkSZKkRpoUxVlj7PnitqrufdEDJPPA/P79+xuEIUmSJDXTZPWJZWBv3/Ye4HKzcCRJkqTt16QoPgccSLIvyRRwBDgzzAGqarGqFqanpxuEIUmSJDUz6JJs9wEPAzcnWU5yZ1VdA44BDwIXgdNVdWGYkyeZT3Li6tWrw8YtSZIkjcygq08cXWf8LHB2syevqkVgcW5u7q7NHkOSJElqqtXHPDtTLEmSpHHQalFsT7EkSZLGQatFsSRJkjQObJ+QJElS59k+IUmSpM6zfUKSJEmdZ/uEJEmSOs/2CUmSJHWe7ROSJEnqPNsnJEmS1Hm2T0iSJKnzbJ+QJElS513XdgCTZvb4A8+/f/LuN7cYiSRJkkbFmWJJkiR1njPFDThrLEmStDO4+oQkSZI6z9UnJEmS1Hm2Twygv01ikH1spZAkSZos3mgnSZKkzrMoliRJUueNvChO8sNJPpbk00neO+rjS5IkSaM2UFGc5GSSK0nOrxo/lOSJJEtJjgNU1cWqeg/ws8Dc6EOWJEmSRmvQmeJ7gUP9A0l2AfcAdwAHgaNJDvZ+9pPA3wJ/NbJIJ8js8Qeef0mSJGn8DVQUV9VDwNdXDd8KLFXVpap6FjgFHO7tf6aqfgx45yiDlSRJkrZCkyXZdgNP9W0vA7cluR14G3A9cHa9DydZABYAZmZmGoQhSZIkNdOkKM4aY1VVnwc+/2IfrqoTwAmAubm5ahCHJEmS1EiTongZ2Nu3vQe4PMwBkswD8/v3728QxnjzoR6SJEnjr8mSbOeAA0n2JZkCjgBnRhOWJEmStH0GXZLtPuBh4OYky0nurKprwDHgQeAicLqqLgxz8qparKqF6enpYeOWJEmSRmag9omqOrrO+Fk2uJnuxXShfaKfrRSSJEnjqUlPcWNVtQgszs3N3dVmHGtxjWFJkqTuaLUo7tpMcb/1im5nkCVJkrafM8VjzHYLSZKk7eFM8ZixbUOSJGn7OVM8IZw1liRJ2jqtFsXaHAtkSZKk0bJ9os8kti54w54kSVJzTZ5o15gP75AkSdI4sH1ih7LFQpIkaXAWxR1ggSxJkrQxe4o7xgJZkiTp27kkW4d5k54kSdKKVm+0kyRJksaBPcX6NhstTecssiRJ2omcKZYkSVLnWRRLkiSp81x9QkPx5jxJkrQTufqERsJiWZIkTTJvtFMrXC9ZkiSNE4tibalBil8LZEmS1DaLYm2bjZZ6kyRJatOWFMVJ3gq8GXgZcE9VfW4rzqOdx1ljSZLUhoGXZEtyMsmVJOdXjR9K8kSSpSTHAarqz6rqLuDdwM+NNGJJkiRpxIZZp/he4FD/QJJdwD3AHcBB4GiSg327/Fbv55IkSdLYGrh9oqoeSjK7avhWYKmqLgEkOQUcTnIRuBv4bFV9YUSxqmMGWebNpeAkSdIoNH2i3W7gqb7t5d7YLwNvAN6e5D1rfTDJQpJHkjzyzDPPNAxDkiRJ2rymN9pljbGqqg8DH97og1V1IsnTwPzU1NQtDeNQhwyyioUzyJIkaRhNZ4qXgb1923uAy4N+uKoWq2phenq6YRiSJEnS5jWdKT4HHEiyD/gKcAR4x6AfTjIPzO/fv79hGNJgXPJNkiStZZgl2e4DHgZuTrKc5M6qugYcAx4ELgKnq+rCoMd0pljjYvb4A8+/JElS9wyz+sTRdcbPAmc3c3JniiVJkjQOWn3Mc1UtAotzc3N3tRmHuslZYUmS9JxWi2JnijVJNiqi11s72b5lSZImgzPF0iqbKWqddZYkabI5UyxtYJTFrjPIkiSNL2eKpTHlA0gkSdo+rRbF0k5nW4UkSZPB9gmpZbZVSJLUvqaPeW7Eh3dIkiRpHNg+IU0YZ5YlSRq9VmeKJUmSpHFgT7E0RrwxT5KkdthTLEmSpM6zp1hqwahmhAfpL15vH3uTJUl6gT3FkiRJ6jxniqUdYthZY0mS9AJvtJN2oK0ufm29kCTtNN5oJ0mSpM6zp1iSJEmdZ0+xJPuRJUmdZ1EsadvZkyxJGjcWxZLGkoWzJGk7jbwoTvJK4DeB6ap6+6iPL2nnskVDktSWgYriJCeBtwBXqupVfeOHgD8AdgF/XFV3V9Ul4M4kn96KgCVNpq0oeH1anyRpVAadKb4X+AjwyecGkuwC7gHeCCwD55KcqarHRx2kpO0zyoJyqwthSZJGZaAl2arqIeDrq4ZvBZaq6lJVPQucAg6POD5JkiRpyzXpKd4NPNW3vQzcluQHgN8GXpPk/VX1O2t9OMkCsAAwMzPTIAxJk2xUM7/rHcdWCknSIJoUxVljrKrq34H3vNiHq+pEkqeB+ampqVsaxCGpRauL0XEuPJv0IFtcS9LO1uSJdsvA3r7tPcDlYQ7gY54lSZI0DprMFJ8DDiTZB3wFOAK8Y5gDJJkH5vfv398gDElbZTOtDZNyI9wgcY77d3H2WpJGZ9Al2e4DbgduTLIMfKCqPp7kGPAgK0uynayqC1sWqSSNia0qRi1yJak9AxXFVXV0nfGzwNnNnryqFoHFubm5uzZ7DEmSJKmpVh/zbPuEpEFsZxvDsOcadP+2Hi7i7LMkDabJjXaNeaOdJEmSxkGrRbEkSZI0DlotipPMJzlx9erVNsOQJElSx9k+IUmSpM6zfUKSJEmd5+oTktSiUa120WSViSaPv5akncL2CUmSJHWe7ROSJEnqPItiSZIkdZ49xZI0htrq592KpwcO+l3WO7f9zJK2gz3FkiRJ6jzbJyRJktR5FsWSJEnqPItiSZIkdZ432knSNmhyA9tW3/w27P6D3Pi2FTFvxiBxT9LDS7YipnH8ntqZxv3fmjfaSZIkqfNsn5AkSVLnWRRLkiSp8yyKJUmS1HkWxZIkSeq8ka8+keQG4A+BZ4HPV9WnRn0OSZIkaZQGmilOcjLJlSTnV40fSvJEkqUkx3vDbwM+XVV3AT854nglSZKkkRu0feJe4FD/QJJdwD3AHcBB4GiSg8Ae4Knebt8cTZiSJEnS1hmofaKqHkoyu2r4VmCpqi4BJDkFHAaWWSmMH2ODojvJArAAMDMzM2zckqQhjeqBGusdZzOL8Q8S0yDna/IwkmH3H+S82/0QkK1+AMmoct40zlH+23ux4w+b5zZt50Ndxv3vookmN9rt5oUZYVgphncD9wM/neSjwOJ6H66qE1U1V1VzN910U4MwJEmSpGaa3GiXNcaqqv4b+MWBDuBjniVJkjQGmswULwN7+7b3AJebhSNJkiRtvyZF8TngQJJ9SaaAI8CZYQ5QVYtVtTA9Pd0gDEmSJKmZQZdkuw94GLg5yXKSO6vqGnAMeBC4CJyuqgvDnDzJfJITV69eHTZuSZIkaWQGXX3i6DrjZ4Gzmz15VS0Ci3Nzc3dt9hiSJElSU60+5tmZYkmSJI2DVFXbMZDkGeDLLZz6RuBrLZxXm2fOJov5mizma7KYr8livsbHD1bVt60HPBZFcVuSPFJVc23HocGZs8liviaL+Zos5muymK/x12r7hCRJkjQOLIolSZLUeV0vik+0HYCGZs4mi/maLOZrspivyWK+xlyne4olSZIkcKZYkiRJ6m5RnORQkieSLCU53nY8WpHkySRfTPJYkkd6Y9+f5C+T/HPvz+/r2//9vRw+keRN7UXeDUlOJrmS5Hzf2ND5SXJLL89LST6cJNv9XbpgnXx9MMlXetfYY0l+ou9n5qtFSfYm+eskF5NcSPIrvXGvsTG0Qb68xiZVVXXuBewC/gV4JTAF/ANwsO24fBXAk8CNq8Z+Dzjee38c+N3e+4O93F0P7OvldFfb32Env4DXA68FzjfJD/D3wI8CAT4L3NH2d9uJr3Xy9UHg19bY13y1n69XAK/tvX8p8KVeXrzGxvC1Qb68xib01dWZ4luBpaq6VFXPAqeAwy3HpPUdBj7Re/8J4K1946eq6n+r6l+BJVZyqy1SVQ8BX181PFR+krwC+J6qerhW/m/wyb7PaITWydd6zFfLqurpqvpC7/03gIvAbrzGxtIG+VqP+RpzXS2KdwNP9W0vs/E/ZG2fAj6X5NEkC72xl1fV07DyHyHgZb1x8zgehs3P7t771ePaPseS/GOvveK5X8WbrzGSZBZ4DfB3eI2NvVX5Aq+xidTVonitXh2X4RgPr6uq1wJ3AO9L8voN9jWP4229/Ji3dn0U+CHg1cDTwO/3xs3XmEjyEuBPgV+tqv/caNc1xszZNlsjX15jE6qrRfEysLdvew9wuaVY1KeqLvf+vAJ8hpV2iK/2fr1E788rvd3N43gYNj/Lvferx7UNquqrVfXNqvoW8Ee80HJkvsZAku9kpcD6VFXd3xv2GhtTa+XLa2xydbUoPgccSLIvyRRwBDjTckydl+SGJC997j3w48B5VnLzrt5u7wL+vPf+DHAkyfVJ9gEHWLlZQdtrqPz0fv37jSQ/0rvD+hf6PqMt9lxx1fNTrFxjYL5a1/v7/Thwsao+1Pcjr7ExtF6+vMYm13VtB9CGqrqW5BjwICsrUZysqgsthyV4OfCZ3ko01wF/UlV/keQccDrJncC/AT8DUFUXkpwGHgeuAe+rqm+2E3o3JLkPuB24Mcky8AHgbobPz3uBe4HvZuVO689u49fojHXydXuSV7Py69kngV8C8zUmXgf8PPDFJI/1xn4Dr7FxtV6+jnqNTSafaCdJkqTO62r7hCRJkvQ8i2JJkiR1nkWxJEmSOs+iWJIkSZ1nUSxJkqTOsyiWJElS51kUS5IkqfMsiiVJktR5/weEsvhzG3vBIwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "(86570, 11)"
+      ]
+     },
+     "execution_count": 129,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADGCAYAAAA6wP2fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAARc0lEQVR4nO3dcaydd13H8feHzk4zsEE3CGl7bfE2i83+AHazqSRkf4B2sksRY9JCFM2yK4Qa/cPEYkzgH+M0SgJhggWagcE1DQ5cQ3EYI5kmi3YjU9bVYa3D3XWhQ0xFY1wGX/+4Z3C8u7c75z7n3Oc593m/kpue87vnPOd7++2zffO93+f3pKqQJEmS+uwlbQcgSZIktc2iWJIkSb1nUSxJkqTesyiWJElS71kUS5IkqfcsiiVJktR7FsWSJEnqPYtiSZIk9d7Ei+IktyT5myQfTXLLpI8vSZIkTdpIRXGS40kuJXl01fqBJI8nOZ/k6GC5gP8Cvh9Ynmy4kiRJ0uRllNs8J3kDK4Xup6rqhsHaNuCrwJtYKX7PAIeBf6qq7yR5JfCBqnrHix3/2muvrT179mz4h5AkSZJG8fDDD3+jqq5bvX7VKG+uqgeS7Fm1fBNwvqouACQ5ARysqscG3/8P4Or1jplkCVgCmJub46GHHholFEmSJGnDknxtrfUmM8U7gSeHni8DO5O8LckfA38CfHi9N1fVsapaqKqF6657QbEuSZIkbZqROsXryBprVVX3AveOdIBkEVicn59vEIYkSZLUTJNO8TKwe+j5LuBis3AkSZKkzdekKD4D7EuyN8l24BBw3zgHqKpTVbW0Y8eOBmFIkiRJzYy6Jds9wIPA9UmWk9xeVc8BR4D7gXPAyao6O86HJ1lMcuzy5cvjxi1JkiRNzEhbsk3bwsJCtbH7xJ6jn/9/z5+4882bHoMkSZI2T5KHq2ph9Xqrt3m2UyxJkqQuaLUodqZYkiRJXdBqUSxJkiR1geMTkiRJ6j3HJyRJktR7jk9IkiSp9xyfkCRJUu85PiFJkqTec3xCkiRJvWdRLEmSpN5zpliSJEm950yxJEmSes/xCUmSJPWeRbEkSZJ6z6JYkiRJveeFdpIkSeo9L7STJElS7zk+IUmSpN6zKJYkSVLvWRRLkiSp9yyKJUmS1HtTKYqTXJPk4SS3TeP4kiRJ0iSNVBQnOZ7kUpJHV60fSPJ4kvNJjg596zeBk5MMVJIkSZqWUTvFdwMHhheSbAPuAm4F9gOHk+xP8kbgMeDrE4xTkiRJmpqrRnlRVT2QZM+q5ZuA81V1ASDJCeAg8FLgGlYK5f9JcrqqvrP6mEmWgCWAubm5jcYvSZIkNTZSUbyOncCTQ8+XgZur6ghAkl8CvrFWQQxQVceAYwALCwvVIA5JkiSpkSZFcdZY+25xW1V3v+gBkkVgcX5+vkEYkiRJUjNNdp9YBnYPPd8FXGwWjiRJkrT5mhTFZ4B9SfYm2Q4cAu4b5wBVdaqqlnbs2NEgDEmSJKmZUbdkuwd4ELg+yXKS26vqOeAIcD9wDjhZVWfH+fAki0mOXb58edy4JUmSpIkZdfeJw+usnwZOb/TDq+oUcGphYeGOjR5DkiRJaqrV2zzbKZYkSVIXtFoUO1MsSZKkLrBTLEmSpN6zUyxJkqTea7UoliRJkrrA8QlJkiT1nuMTkiRJ6j3HJyRJktR7FsWSJEnqPWeKJUmS1HvOFEuSJKn3HJ+QJElS713VdgCzZs/Rz3/38RN3vrnFSCRJkjQpdoolSZLUe3aKG7BrLEmStDW4+4QkSZJ6z90nJEmS1HuOT4xgeExilNc4SiFJkjRbvNBOkiRJvWdRLEmSpN6zKJYkSVLvTbwoTvJjST6a5DNJ3j3p40uSJEmTNtKFdkmOA7cBl6rqhqH1A8AHgW3Ax6vqzqo6B7wryUuAj00h5s7zojtJkqTZMmqn+G7gwPBCkm3AXcCtwH7gcJL9g++9Bfhb4K8mFqkkSZI0JSMVxVX1APDNVcs3Aeer6kJVPQucAA4OXn9fVf0k8I71jplkKclDSR565plnNha9JEmSNAFN9ineCTw59HwZuDnJLcDbgKuB0+u9uaqOJXkaWNy+ffuNDeKQJEmSGmlSFGeNtaqqLwFfGuUAVXUKOLWwsHBHgzg6zfliSZKk7muy+8QysHvo+S7g4jgHSLKY5Njly5cbhCFJkiQ106RTfAbYl2Qv8BRwCHj7OAfoQ6d4mF1jSZKkbhqpU5zkHuBB4Poky0lur6rngCPA/cA54GRVnR3nw+0US5IkqQtG6hRX1eF11k9zhYvpRjhuZzvFw11dSZIkbW1NxicaS7IILM7Pz7cZRivWK7odq5AkSdp8rRbFXe4Ud4EzyJIkSZvDTnHHOLYhSZK0+ewUzwi7xpIkSdPTalGsjbFAliRJmizHJ4bM+uiCxbIkSdLGOD4x42a9kJckSeoCxye2KLvGkiRJo7Mo7gELZEmSpCtzprhnLJAlSZJeyJniHvOuepIkSSte0nYAkiRJUtucKdYLXGlHC7vIkiRpK7JTLEmSpN6zKJYkSVLvufuExuLuFZIkaSty9wlt2HoFsoWzJEmaNV5op4kY93bTFs6SJKlLLIrVOgtkSZLUNotiTZUFryRJmgVTKYqTvBV4M/AK4K6q+uI0PkezZdwRC0mSpM0yclGc5DhwG3Cpqm4YWj8AfBDYBny8qu6sqs8Bn0vycuAPAItijcTOsiRJasM4+xTfDRwYXkiyDbgLuBXYDxxOsn/oJb89+L4kSZLUWSN3iqvqgSR7Vi3fBJyvqgsASU4AB5OcA+4EvlBVX55QrOqZUbrG641k2GWWJEnjaDpTvBN4cuj5MnAz8KvAG4EdSear6qOr35hkCVgCmJubaxiGtjrHKiRJ0jQ1LYqzxlpV1YeAD13pjVV1LMnTwOL27dtvbBiHemSUC/YsoiVJ0jiaFsXLwO6h57uAi6O+2TvaaTNYIEuSpBfTtCg+A+xLshd4CjgEvH3UNydZBBbn5+cbhiGNxgJZkiStZeTdJ5LcAzwIXJ9kOcntVfUccAS4HzgHnKyqs6Mes6pOVdXSjh07xo1bkiRJmphxdp84vM76aeD0Rj7cTrG6wg6yJEn9Ns4+xRNnp1iSJEldMJXbPI/KTrHaNO5tp6/0+uHusl1nSZJmT6tFsbtPaKsYt8CWJEndYqdYWmVanV47yJIkdZedYukK2uwAewtrSZI2T6sX2kmSJEld4PiENEXeklqSpNnglmySJEnqvVY7xZLGZ2dZkqTJc6ZYkiRJvedMsdQh7ncsSVI7nCmWJElS7zlTLLVgUh3hUeaL13uNs8mSJH2PM8WSJEnqPTvFUo84syxJ0tq80E7aIjaz4HX0QpK01XihnSRJknrPmWJJkiT1njPFksbexUKSpK3GoljSpnMmWZLUNRbFkjrJwlmStJkmPlOc5NVJPpHkM5M+tiRJkjQNI3WKkxwHbgMuVdUNQ+sHgA8C24CPV9WdVXUBuN2iWNKwUWaSx51b9m59kqRJGXV84m7gw8Cnnl9Isg24C3gTsAycSXJfVT026SAlbZ5JFpTTuDjPC/4kSdMw0vhEVT0AfHPV8k3A+aq6UFXPAieAgxOOT5IkSZq6Jhfa7QSeHHq+DNyc5IeB3wFem+S9VfW7a705yRKwBDA3N9cgDEmzbFKd3/WO4yiFJGkUTYrirLFWVfXvwLte7M1VdSzJ08Di9u3bb2wQh6QWrS5Gu1x4NplBtriWpK2tye4Ty8Duoee7gIvjHMDbPEuSJKkLmnSKzwD7kuwFngIOAW8f5wBJFoHF+fn5BmFI6pJZuRBuGrthbDa715I0OaNuyXYPcAtwbZJl4H1V9YkkR4D7WdmS7XhVnZ1apJI2XdeLwrZMqxi1yJWk9oxUFFfV4XXWTwOnN/rhVXUKOLWwsHDHRo8hSZIkNdXqbZ4dn5A0is3sWDe5gciwK3V6N7MjbPdZkkYz8ds8j8ML7SRJktQFrRbFkiRJUhc4PiFJUzBL+zdLkhyfkCRJkhyfkCRJkhyfkKQWTWq3iya7TDS5/bUkbRWOT0iSJKn3HJ+QJElS71kUS5IkqfecKZakDmprnncadw8c9WfZyN0BJWlSnCmWJElS7zk+IUmSpN6zKJYkSVLvWRRLkiSp97zQTpI2QZML2KZ98du4rx/lwrdpxLwRo8Q9SzcvmUZMXfw5tTV1/d+aF9pJkiSp9xyfkCRJUu9ZFEuSJKn3LIolSZLUexbFkiRJ6r2J7z6R5Brgj4BngS9V1acn/RmSJEnSJI3UKU5yPMmlJI+uWj+Q5PEk55McHSy/DfhMVd0BvGXC8UqSJEkTN+r4xN3AgeGFJNuAu4Bbgf3A4ST7gV3Ak4OXfXsyYUqSJEnTM9L4RFU9kGTPquWbgPNVdQEgyQngILDMSmH8CFcoupMsAUsAc3Nz48YtSRrTpG6osd5xNrIZ/ygxjfJ5TW5GMu7rR/nczb4JyLRvQDKpnDeNc5L/9l7s+OPmuU2beVOXrv9dNNHkQrudfK8jDCvF8E7gXuDnknwEOLXem6vqWFUtVNXCdddd1yAMSZIkqZkmF9pljbWqqv8GfnmkA3ibZ0mSJHVAk07xMrB76Pku4GKzcCRJkqTN16QoPgPsS7I3yXbgEHDfOAeoqlNVtbRjx44GYUiSJEnNjLol2z3Ag8D1SZaT3F5VzwFHgPuBc8DJqjo7zocnWUxy7PLly+PGLUmSJE3MqLtPHF5n/TRweqMfXlWngFMLCwt3bPQYkiRJUlOt3ubZTrEkSZK6IFXVdgwkeQb4WgsffS3wjRY+VxtnzmaL+Zot5mu2mK/ZYr6640eq6gX7AXeiKG5LkoeqaqHtODQ6czZbzNdsMV+zxXzNFvPVfa2OT0iSJEldYFEsSZKk3ut7UXys7QA0NnM2W8zXbDFfs8V8zRbz1XG9nimWJEmSwE6xJEmS1N+iOMmBJI8nOZ/kaNvxaEWSJ5J8JckjSR4arP1Qkr9M8s+DP18+9Pr3DnL4eJKfbi/yfkhyPMmlJI8OrY2dnyQ3DvJ8PsmHkmSzf5Y+WCdf70/y1OAceyTJzwx9z3y1KMnuJH+d5FySs0l+bbDuOdZBV8iX59isqqrefQHbgH8BXg1sB/4B2N92XH4VwBPAtavWfh84Onh8FPi9weP9g9xdDewd5HRb2z/DVv4C3gC8Dni0SX6Avwd+AgjwBeDWtn+2rfi1Tr7eD/zGGq81X+3n61XA6waPXwZ8dZAXz7EOfl0hX55jM/rV107xTcD5qrpQVc8CJ4CDLcek9R0EPjl4/EngrUPrJ6rqf6vqX4HzrORWU1JVDwDfXLU8Vn6SvAr4wap6sFb+b/CpofdogtbJ13rMV8uq6umq+vLg8beAc8BOPMc66Qr5Wo/56ri+FsU7gSeHni9z5X/I2jwFfDHJw0mWBmuvrKqnYeU/QsArBuvmsRvGzc/OwePV69o8R5L842C84vlfxZuvDkmyB3gt8Hd4jnXeqnyB59hM6mtRvNasjttwdMPrq+p1wK3Ae5K84QqvNY/dtl5+zFu7PgL8KPAa4GngDwfr5qsjkrwU+DPg16vqP6/00jXWzNkmWyNfnmMzqq9F8TKwe+j5LuBiS7FoSFVdHPx5CfgsK+MQXx/8eonBn5cGLzeP3TBufpYHj1evaxNU1der6ttV9R3gY3xv5Mh8dUCS72OlwPp0Vd07WPYc66i18uU5Nrv6WhSfAfYl2ZtkO3AIuK/lmHovyTVJXvb8Y+CngEdZyc07By97J/Dng8f3AYeSXJ1kL7CPlYsVtLnGys/g17/fSvLjgyusf3HoPZqy54urgZ9l5RwD89W6wd/vJ4BzVfWBoW95jnXQevnyHJtdV7UdQBuq6rkkR4D7WdmJ4nhVnW05LMErgc8OdqK5CvjTqvqLJGeAk0luB/4N+HmAqjqb5CTwGPAc8J6q+nY7ofdDknuAW4BrkywD7wPuZPz8vBu4G/gBVq60/sIm/hi9sU6+bknyGlZ+PfsE8Ctgvjri9cAvAF9J8shg7bfwHOuq9fJ12HNsNnlHO0mSJPVeX8cnJEmSpO+yKJYkSVLvWRRLkiSp9yyKJUmS1HsWxZIkSeo9i2JJkiT1nkWxJEmSes+iWJIkSb33f8d/EvLDQqLQAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -910,17 +1013,28 @@
     "fig = plt.figure(figsize=(12,3))\n",
     "ax = fig.add_subplot(111)\n",
     "plt.hist(df1.raw_value, bins=200)\n",
-    "ax.set_yscale('log')"
+    "ax.set_yscale('log')\n",
+    "df1.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAARt0lEQVR4nO3db4xcV3nH8e8P0w1SoC6QUCHbW5vaimrxopCV039CkQrFIVlMaVXZrVRaRVnR1lX7ohJGVIK+S6u2EigpkUssQ4Vi0jSltjAKFS0ylSKwgwLEWCkmDcriCJdSbWlVNQ08fbGTMGx3nJm9M74ze78f6cozZ+ee+6zP3t1nzjz33FQVkiRJUpe9qO0AJEmSpLaZFEuSJKnzTIolSZLUeSbFkiRJ6jyTYkmSJHWeSbEkSZI678VtBwBw3XXX1c6dO9sOQ5IkSZvcI4888q2qun5te6tJcZJFYHH37t2cO3euzVAkSZLUAUm+vl57q+UTVXWqqpa2bt3aZhiSJEnqOGuKJUmS1HkmxZIkSeo8k2JJkiR13tiT4iQ3J/lsknuS3Dzu/iVJkqRxG2r1iSTHgNuAy1X12r72/cD7gS3Ah6rqTqCA/wReAiyPPeIx2nnkEz/w/Mk7b20pEkmSJLVp2Jni48D+/oYkW4C7gVuAvcChJHuBz1bVLcC7gD8aX6iSJEnSZAyVFFfVGeDba5r3ARer6omqegY4ARyoqu/1vv7vwDVji1SSJEmakCY379gGPNX3fBm4KcnbgTcDPwLcNWjnJEvAEsD8/HyDMCRJkqRmmiTFWaetqupB4MEX2rmqjiZ5Glicm5u7sUEckiRJUiNNVp9YBnb0Pd8OXBqlA+9oJ0mSpGnQJCk+C+xJsivJHHAQODlKB0kWkxxdWVlpEIYkSZLUzFBJcZL7gIeBG5IsJ7m9qp4FDgMPAReA+6vq/ORClSRJkiZjqJriqjo0oP00cHqjB6+qU8CphYWFOzbahyRJktRUq7d5tnxCkiRJ06DVpNgL7SRJkjQNWk2KJUmSpGlg+YQkSZI6z/IJSZIkdZ4zxZIkSeo8Z4olSZLUeV5oJ0mSpM4zKZYkSVLnWVMsSZKkzrOmWJIkSZ1n+YQkSZI6z6RYkiRJnWdSLEmSpM7zQjtJkiR1nhfaSZIkqfMsn5AkSVLnmRRLkiSp80yKJUmS1HkTSYqTXJvkkSS3TaJ/SZIkaZyGSoqTHEtyOclja9r3J3k8ycUkR/q+9C7g/nEGKkmSJE3KsDPFx4H9/Q1JtgB3A7cAe4FDSfYmeSPwFeCbY4xTkiRJmpgXD/OiqjqTZOea5n3Axap6AiDJCeAA8FLgWlYT5f9Ocrqqvje2iCVJkqQxGyopHmAb8FTf82Xgpqo6DJDkN4BvDUqIkywBSwDz8/MNwpAkSZKaaZIUZ522ev5B1fEr7VxVR5M8DSzOzc3d2CAOSZIkqZEmSfEysKPv+Xbg0igdVNUp4NTCwsIdDeIYm51HPvH84yfvvLXFSCRJknQ1NVmS7SywJ8muJHPAQeDkKB0kWUxydGVlpUEYkiRJUjPDLsl2H/AwcEOS5SS3V9WzwGHgIeACcH9VnZ9cqJIkSdJkDLv6xKEB7aeB0xs9+LSVT0iSJKmbWr3Ns+UTkiRJmgatJsVVdaqqlrZu3dpmGJIkSeq4VpNiSZIkaRpYPiFJkqTOs3xCkiRJndfk5h2NJVkEFnfv3t1mGOvyRh6SJEnd4UyxJEmSOs8L7SRJktR5JsWSJEnqPFefkCRJUudZUyxJkqTOs3xCkiRJnWdSLEmSpM4zKZYkSVLnefOOIXgjD0mSpM3NC+0kSZLUeZZPSJIkqfNMiiVJktR5JsWSJEnqvLEnxUl+Isk9SR5I8lvj7l+SJEkat6GS4iTHklxO8tia9v1JHk9yMckRgKq6UFXvBH4FWBh/yJIkSdJ4DTtTfBzY39+QZAtwN3ALsBc4lGRv72tvBf4J+PTYIp0SO4984vlNkiRJm8NQSXFVnQG+vaZ5H3Cxqp6oqmeAE8CB3utPVtXPAL82zmAlSZKkSWhy845twFN9z5eBm5LcDLwduAY4PWjnJEvAEsD8/HyDMCRJkqRmmiTFWaetquozwGdeaOeqOprkaWBxbm7uxgZxSJIkSY00WX1iGdjR93w7cGmUDryjnSRJkqZBk6T4LLAnya4kc8BB4OQoHSRZTHJ0ZWWlQRiSJElSM8MuyXYf8DBwQ5LlJLdX1bPAYeAh4AJwf1WdH+XgzhRLkiRpGgxVU1xVhwa0n+YKF9O9kCSLwOLu3bs32oUkSZLUmLd5liRJUuc1WX2isao6BZxaWFi4o804Nqr/Bh5P3nlri5FIkiSpiVaTYqlLfBMlSdL0ajUptqZYs2xQkjtM8ttkX0mSNH6pqrZjYGFhoc6dO3fVj9ufgDRlArN5jPPnYhL8WZMkaeOSPFJVC2vbLZ+QZswwSbuJsyRJo7F8Qp0y7bPAk2BJhiRJL8zVJ7TpdT0RHqZ9UF3zoNdIkrTZWD4xJs7GTZcuJsJN+P8lSeo6yye0aZjYTZZv/CRJm5nlE5ppJsLtMEGWJG02lk9IamTYNyYmz5KkaWZSrJnj7PDsc6ZZkjRtTIolXRW+mZEkTTMvtJPUKpeAkyRNAy+009RyZrHbBpVYWHohSZoEyyc0VUyENQoTZEnSuJgUq3Umwnoh/oxIkibNpHgCnL2S2uU5KEka1YvaDkCSJElq20RmipO8DbgVeBVwd1V9ahLHkaTnWGIhSWpi6KQ4yTHgNuByVb22r30/8H5gC/Chqrqzqj4OfDzJy4E/BUyK5UfaaoWrWEiShjHKTPFx4C7gI881JNkC3A28CVgGziY5WVVf6b3kD3tf7yz/8K7PWT21wZ87SdIgQyfFVXUmyc41zfuAi1X1BECSE8CBJBeAO4FPVtUX1usvyRKwBDA/Pz965JI0Jr55lSQ1rSneBjzV93wZuAn4XeCNwNYku6vqnrU7VtXRJE8Di3Nzczc2jENTypk5zRoTZEnqpqZJcdZpq6r6APCBF9rZO9pJmhUmy5K0uTVdkm0Z2NH3fDtwadidkywmObqystIwDEmSJGnjms4UnwX2JNkFfAM4CPzqsDs7Uyxpmg0q/3HWWJI2n1GWZLsPuBm4Lsky8N6qujfJYeAhVpdkO1ZV50focxFY3L1792hRS9KUMEGWpM1hlNUnDg1oPw2c3sjBuzZT7B9PSZKk6dTqbZ6tKZYkSdI0mMhtnofVtZnirnAZNkmSNGtaTYq7XFNsKYXULYPeLHr+S9J0cKZYksbET0kkaXa1WlMsSZIkTQPLJzQWzpBJG2MplSRNB8sntGEmwtLkmCxL0tVl+YQkSZI6z/IJSZoS3lZaktpj+YQkzZBhEmSTaEkaneUTkiRJ6rxWZ4olSRvnjLAkjY8zxZIkSeo8Z4o1Epdhk6aT56YkNePqE5LUEZZbSNJgrj4xBab9D5UzUJIkabOzpliSJEmdZ02xJOl50/7JlSRNijPFkiRJ6ryxJ8VJXpPk3iQPjLtvSZIkaRKGKp9Icgy4DbhcVa/ta98PvB/YAnyoqu6sqieA202KJal947pQdlA/llhI2iyGrSk+DtwFfOS5hiRbgLuBNwHLwNkkJ6vqK+MOUpI0Xq4qI0k/aKikuKrOJNm5pnkfcLE3M0ySE8ABYKikOMkSsAQwPz8/ZLibX1sXuXhxjaRx8neKpFnTpKZ4G/BU3/NlYFuSVya5B3hdkncP2rmqjlbVQlUtXH/99Q3CkCRJkpppsiRb1mmrqvo34J1DdeAd7TbE2j5JV8MwJRbOCEvaLJokxcvAjr7n24FLzcKRJHWJSbWkadGkfOIssCfJriRzwEHg5CgdVNWpqlraunVrgzAkSZKkZoZdku0+4GbguiTLwHur6t4kh4GHWF2S7VhVnR/l4JZPTCevSpe0Ef7ukDTLhl194tCA9tPA6Y0evKpOAacWFhbu2GgfkiRJUlNNaoobc6Z4eM7ASNL4WMssaa2x3+Z5FNYUS5IkaRo4UyxJmqhhP+kaNHvrTY0kXQ3OFEuSJKnzWk2KJUmSpGlg+cQUm8TFdV6wJ2mzsLxB0jhZPiFJkqTOs3xCkiRJnWf5xCZiaYSkzWLWy8eGKe1YG8+oJSCTKB+xJEVdZvmEJEmSOs/yCUmSJHWeSbEkSZI6z6RYkiRJnWdSLEmSpM5z9QlJ0qYy6VUZrkY/g14366tMjPO4rpShcXP1CUmSJHWe5ROSJEnqPJNiSZIkdZ5JsSRJkjpv7BfaJbkW+AvgGeAzVfXRcR9DkiRJGqehZoqTHEtyOclja9r3J3k8ycUkR3rNbwceqKo7gLeOOV5JkiRp7IYtnzgO7O9vSLIFuBu4BdgLHEqyF9gOPNV72XfHE6YkSZI0OUOVT1TVmSQ71zTvAy5W1RMASU4AB4BlVhPjR7lC0p1kCVgCmJ+fHzVuSVIHDVq/d9T2UftvounaxE2O179+b5P+h1k3edTjDvv6Jn0Nes0gw6x33KSfq7FO8zSv3zzNsUGzC+228f0ZYVhNhrcBDwK/lOSDwKlBO1fV0apaqKqF66+/vkEYkiRJUjNNLrTLOm1VVf8F/OZQHXhHO0mSJE2BJjPFy8COvufbgUvNwpEkSZKuviZJ8VlgT5JdSeaAg8DJUTrwNs+SJEmaBsMuyXYf8DBwQ5LlJLdX1bPAYeAh4AJwf1WdH+XgSRaTHF1ZWRk1bkmSJGlshl194tCA9tPA6Y0evKpOAacWFhbu2GgfkiRJUlOt3ubZmWJJkiRNg1RV2zGQ5F+Br7dw6OuAb7VwXG2M4zU7HKvZ4VjNDsdqdjhW0+3Hqur/rQc8FUlxW5Kcq6qFtuPQcByv2eFYzQ7HanY4VrPDsZpNrZZPSJIkSdPApFiSJEmd1/Wk+GjbAWgkjtfscKxmh2M1Oxyr2eFYzaBO1xRLkiRJ4EyxJEmS1N2kOMn+JI8nuZjkSNvxdFWSJ5N8OcmjSc712l6R5O+TfLX378v7Xv/u3pg9nuTNfe039vq5mOQDSdLG97OZJDmW5HKSx/raxjY2Sa5J8rFe++eS7Lya399mMmCs3pfkG71z69Ekb+n7mmPVgiQ7kvxjkgtJzif5vV6759UUusJ4eW5tVlXVuQ3YAnwNeA0wB3wR2Nt2XF3cgCeB69a0/QlwpPf4CPDHvcd7e2N1DbCrN4Zbel/7PPDTQIBPAre0/b3N+ga8AXg98Ngkxgb4beCe3uODwMfa/p5ndRswVu8D/mCd1zpW7Y3Tq4HX9x6/DPjn3nh4Xk3hdoXx8tzapFtXZ4r3ARer6omqegY4ARxoOSZ93wHgw73HHwbe1td+oqr+p6r+BbgI7EvyauCHq+rhWv3N8pG+fbRBVXUG+Paa5nGOTX9fDwA/7wz/xgwYq0Ecq5ZU1dNV9YXe4+8AF4BteF5NpSuM1yCO14zralK8DXiq7/kyV/5B1+QU8KkkjyRZ6rX9aFU9Dau/lIBX9doHjdu23uO17Rq/cY7N8/tU1bPACvDKiUXeTYeTfKlXXvHcR/KO1RTofUz+OuBzeF5NvTXjBZ5bm1JXk+L13oW5DEc7fraqXg/cAvxOkjdc4bWDxs3xbN9GxsZxm6wPAj8O/CTwNPBnvXbHqmVJXgr8DfD7VfUfV3rpOm2O1VW2znh5bm1SXU2Kl4Edfc+3A5daiqXTqupS79/LwN+yWtryzd7HTfT+vdx7+aBxW+49Xtuu8Rvn2Dy/T5IXA1sZvgRAL6CqvllV362q7wF/yeq5BY5Vq5L8EKsJ1ker6sFes+fVlFpvvDy3Nq+uJsVngT1JdiWZY7W4/WTLMXVOkmuTvOy5x8AvAI+xOhbv6L3sHcDf9R6fBA72rtbdBewBPt/7uPE7SX6qV4v16337aLzGOTb9ff0y8A+9ejuNwXNJVs8vsnpugWPVmt7/673Ahar6874veV5NoUHj5bm1ibV9pV9bG/AWVq8k/Rrwnrbj6eLG6uofX+xt558bB1brqT4NfLX37yv69nlPb8wep2+FCWCB1V9MXwPuondjGrdG43Mfqx8N/i+rsxm3j3NsgJcAf83qxSifB17T9vc8q9uAsfor4MvAl1j9w/tqx6r1cfo5Vj8a/xLwaG97i+fVdG5XGC/PrU26eUc7SZIkdV5XyyckSZKk55kUS5IkqfNMiiVJktR5JsWSJEnqPJNiSZIkdZ5JsSRJkjrPpFiSJEmdZ1IsSZKkzvs/a0XnWf73R3sAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "(165171, 11)"
+      ]
+     },
+     "execution_count": 130,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAR6UlEQVR4nO3df6xcaV3H8ffHYpdkwQbYYkh/2GKbjY1/CE6Kv0JIRG1ZShGJaWMimk1vUGv0DxNKMBHjP6tREwkr61WaBUK2rLhibyhZDLqpJhtolyzQ0tQtdcleS+gi5orGuC58/ePOluFypzv3nrk9M3Per2TSmWfmPOeZfufc+73PfM9zUlVIkiRJXfY9bQ9AkiRJaptJsSRJkjrPpFiSJEmdZ1IsSZKkzjMpliRJUueZFEuSJKnzXtD2AADuuOOO2rVrV9vDkCRJ0ox77LHHvlZVW1e2t5oUJzkEHNqzZw/nz59vcyiSJEnqgCRfXq291fKJqlqoqrktW7a0OQxJkiR1nDXFkiRJ6jyTYkmSJHWeSbEkSZI6z6RYkiRJnTf21SeSvA74A+AicKqqHhn3PsZl14mPf8fjJ++5q6WRSJIkqU0jzRQnOZnkepILK9oPJLmc5EqSE/3mAv4LeCGwON7hSpIkSeM3avnE/cCBwYYkm4B7gYPAPuBokn3AP1XVQeAdwO+Pb6iSJEnSxhgpKa6qs8DXVzTvB65U1dWqegY4BRyuqm/1n/8P4LZhfSaZS3I+yfmnn356HUOXJEmSxqPJiXbbgKcGHi8C25K8JclfAB8C3jts46qar6peVfW2bv2uK+1JkiRJt0yTE+2ySltV1UPAQyN1MHCZZ0mSJKktTWaKF4EdA4+3A9eaDUeSJEm69ZokxeeAvUl2J9kMHAFOr6WDqlqoqrktW7Y0GIYkSZLUzKhLsj0APArcmWQxyd1V9SxwHHgYuAQ8WFUX17LzJIeSzC8tLa113JIkSdLYjFRTXFVHh7SfAc6sd+dVtQAs9Hq9Y+vtQ5IkSWqq1cs8O1MsSZKkSdBqUmxNsSRJkiaBM8WSJEnqPGeKJUmS1HmtJsWSJEnSJLB8QpIkSZ1n+YQkSZI6z/IJSZIkdZ7lE5IkSeo8yyckSZLUeZZPSJIkqfNMiiVJktR5JsWSJEnqPJNiSZIkdZ6rT0iSJKnzXH1CkiRJnWf5hCRJkjrPpFiSJEmdZ1IsSZKkztuQpDjJ7UkeS/LGjehfkiRJGqeRkuIkJ5NcT3JhRfuBJJeTXElyYuCpdwAPjnOgkiRJ0kYZdab4fuDAYEOSTcC9wEFgH3A0yb4krwe+CHx1jOOUJEmSNswLRnlRVZ1NsmtF837gSlVdBUhyCjgMvAi4neVE+X+SnKmqb63sM8kcMAewc+fO9Y5fkiRJamykpHiIbcBTA48XgddU1XGAJL8CfG21hBigquaBeYBer1cNxiFJkiQ10iQpziptN5Lbqrr/eTtIDgGH9uzZ02AYkiRJUjNNkuJFYMfA4+3AtWbDadeuEx+/cf/Je+5qcSSSJEm6lZosyXYO2Jtkd5LNwBHg9Fo68DLPkiRJmgSjLsn2APAocGeSxSR3V9WzwHHgYeAS8GBVXVzLzpMcSjK/tLS01nFLkiRJYzPq6hNHh7SfAc6sd+dVtQAs9Hq9Y+vtQ5IkSWqq1cs8O1MsSZKkSdBqUmxNsSRJkiaBM8WSJEnqPGeKJUmS1HmtJsWSJEnSJGhy8Y7GJvmKdl7IQ5IkqTssn5AkSVLnWT4hSZKkznP1CUmSJHWe5ROSJEnqPMsnJEmS1HkmxZIkSeo8k2JJkiR1XqvrFE8L1yyWJEmaba4+IUmSpM5z9QlJkiR1njXFkiRJ6jyTYkmSJHWeSbEkSZI6b+xJcZIfSnJfko8m+bVx9y9JkiSN20hJcZKTSa4nubCi/UCSy0muJDkBUFWXqurtwC8CvfEPWZIkSRqvUWeK7wcODDYk2QTcCxwE9gFHk+zrP/cm4J+BT41tpBNi14mP37hJkiRpNoyUFFfVWeDrK5r3A1eq6mpVPQOcAg73X3+6qn4C+KVhfSaZS3I+yfmnn356faOXJEmSxqDJFe22AU8NPF4EXpPkdcBbgNuAM8M2rqp5YB6g1+tVg3FIkiRJjTRJirNKW1XVI8AjI3WQHAIO7dmzp8EwJEmSpGaarD6xCOwYeLwduNZsOJIkSdKt1yQpPgfsTbI7yWbgCHB6LR14mWdJkiRNglGXZHsAeBS4M8likrur6lngOPAwcAl4sKourmXnSQ4lmV9aWlrruCVJkqSxGammuKqODmk/w01Ophuh3wVgodfrHVtvH5IkSVJTTU60a2zaT7QbXKv4yXvuanEkmiTDPhejfF78TEmS1I5Wk2JnijVNbnbBFhNYSZKmW6raWyJ4YKb42BNPPHHL9z/Oq9KZFM2Oab1aoZ9BSZKeX5LHqqq3st2ZYmlGWHohSdL6tZoUS7fasFngWUsiR3mfJtGSJH2bJ9ppJq21BGJaSybWatj7HOX9mzhLkmaZ5ROSRuLMsiRpllk+MSYmDO3rymzvJPDzLkmaNZZPaKqZCLdv1BiYPEuSJpnlE5JuCWeXJUmTzPIJTR1nh6efCbIkadKYFEtqlQmyJGkSmBRrKjg73A2uryxJaotJsSaWibAkSbpVXH1CE8VEWKsZ5aIjzhpLkppw9Qm1zkRYkiS1zfIJSTNhlHpkSZKGMSneAH6lK00Oj0dJ0ii+p+0BSJIkSW3bkJniJG8G7gJeDtxbVZ/ciP1oujhjp0liuYUkadDISXGSk8AbgetV9cMD7QeAPwM2AX9VVfdU1ceAjyV5CfDHgEmxvoMn16kNfu4kScOsZab4fuC9wAefa0iyCbgX+BlgETiX5HRVfbH/kt/tPy9JU8FvNCSpm0ZOiqvqbJJdK5r3A1eq6ipAklPA4SSXgHuAT1TVZ1frL8kcMAewc+fOtY98SnT9F6wzc5pmllhIUnc0rSneBjw18HgReA3wm8DrgS1J9lTVfSs3rKp5YB6g1+tVw3FI0i3T9T92JWkWNU2Ks0pbVdV7gPc878Ze0U6SJEkToGlSvAjsGHi8HbjWsE9JmhrOGkvSbGi6TvE5YG+S3Uk2A0eA06NuXFULVTW3ZcuWhsOQJEmS1m/kpDjJA8CjwJ1JFpPcXVXPAseBh4FLwINVdXENfR5KMr+0tLTWcUuSJEljs5bVJ44OaT8DnFnPzqtqAVjo9XrH1rO9JEmSNA4bckW7UXXtRDtrD6Xu8viXpMnWalLsTPFscm1iddWon30TZEmaPE1PtGvEmmJJkiRNAmeKJalFzhpL0mRoNSnuMn8RSpIkTQ5PtNNYWEcsjZd/OEvSrWX5hNbNRFgar1GOKZNlSdoYlk9I0oTzD1BJ2niWT0jSjHE2WZLWzvIJSZpSJr+SND6WT0jSDLDEQpKaMSnWmviLV5IkzSKTYknqCMstJGm4Vi/zLEmSJE2CVpPiJIeSzC8tLbU5DEmSJHWcq09MgEn/StM6YkmSNOusKZakGeYftZI0GpNiSdINk/7NlSRtFJNiSdLzMlmWNOvGnhQneSXwLmBLVb113P1Lkpobpaxi2GtMkCXNopFWn0hyMsn1JBdWtB9IcjnJlSQnAKrqalXdvRGDlSRJkjbCqEuy3Q8cGGxIsgm4FzgI7AOOJtk31tFJkiRJt8BI5RNVdTbJrhXN+4ErVXUVIMkp4DDwxVH6TDIHzAHs3LlzxOHOvra+lvTrUEnrMexnhz9TJE2bJhfv2AY8NfB4EdiW5GVJ7gNeleSdwzauqvmq6lVVb+vWrQ2GIUmSJDXT5ES7rNJWVfXvwNtH6iA5BBzas2dPg2F0z7CTX5yNkSRJWp8mSfEisGPg8XbgWrPhSJKm1XouFOIf+ZImRZPyiXPA3iS7k2wGjgCn19JBVS1U1dyWLVsaDEOSJElqZqSZ4iQPAK8D7kiyCPxeVb0/yXHgYWATcLKqLq5l55ZPTCYvCytpnDzpTtI0GHX1iaND2s8AZ9a786paABZ6vd6x9fYhSZIkNdXqZZ6dKR6ds7eSumSjZ5edvZa0UpOa4sasKZYkSdIkcKZYknTLNF2hwosaSdoozhRLkiSp81pNiiVJkqRJYPnEBNuIk+s8YU/SrFhrecOs/fyzvEMaL8snJEmS1HmWT0iSJKnzTIolSZLUedYUz5BZq5eTpPXYiFrbJvXLw16/8mf2JNQFW6esLrOmWJIkSZ1n+YQkSZI6z6RYkiRJnWdSLEmSpM7zRDtJ0tRY6wnFk3YRpFG3Hfa6Jie/bUSfw/of5eTCpvtt0pcnFGo1nmgnSZKkzrN8QpIkSZ1nUixJkqTOMymWJElS5439RLsktwN/DjwDPFJVHx73PiRJkqRxGmmmOMnJJNeTXFjRfiDJ5SRXkpzoN78F+GhVHQPeNObxSpIkSWM3avnE/cCBwYYkm4B7gYPAPuBokn3AduCp/su+OZ5hSpIkSRtnpPKJqjqbZNeK5v3Alaq6CpDkFHAYWGQ5MX6cmyTdSeaAOYCdO3euddySJN0wrvWI21zXeCPew0asQTxolP6HbTtsnCtff7Pnnq+vJuMYZdth2lyneZLXb5709aGbnGi3jW/PCMNyMrwNeAj4hSTvAxaGbVxV81XVq6re1q1bGwxDkiRJaqbJiXZZpa2q6r+BXx2pA69oJ0mSpAnQZKZ4Edgx8Hg7cK3ZcCRJkqRbr0lSfA7Ym2R3ks3AEeD0WjrwMs+SJEmaBKMuyfYA8ChwZ5LFJHdX1bPAceBh4BLwYFVdXMvOkxxKMr+0tLTWcUuSJEljM+rqE0eHtJ8Bzqx351W1ACz0er1j6+1DkiRJaqrVyzw7UyxJkqRJkKpqewwkeRr4cgu7vgP4Wgv71foYr+lhrKaHsZoexmp6GKvJ9gNV9V3rAU9EUtyWJOerqtf2ODQa4zU9jNX0MFbTw1hND2M1nVotn5AkSZImgUmxJEmSOq/rSfF82wPQmhiv6WGspoexmh7GanoYqynU6ZpiSZIkCZwpliRJkrqbFCc5kORykitJTrQ9nq5K8mSSLyR5PMn5fttLk/x9kif6/75k4PXv7MfscpKfG2j/0X4/V5K8J0naeD+zJMnJJNeTXBhoG1tsktyW5CP99k8n2XUr398sGRKrdyf5t/6x9XiSNww8Z6xakGRHkn9McinJxSS/1W/3uJpAN4mXx9asqqrO3YBNwJeAVwKbgc8B+9oeVxdvwJPAHSva/gg40b9/AvjD/v19/VjdBuzux3BT/7nPAD8OBPgEcLDt9zbtN+C1wKuBCxsRG+DXgfv6948AH2n7PU/rbUis3g38ziqvNVbtxekVwKv7918M/Es/Hh5XE3i7Sbw8tmb01tWZ4v3Alaq6WlXPAKeAwy2PSd92GPhA//4HgDcPtJ+qqv+tqn8FrgD7k7wC+L6qerSWf7J8cGAbrVNVnQW+vqJ5nLEZ7OujwE87w78+Q2I1jLFqSVV9pao+27//DeASsA2Pq4l0k3gNY7ymXFeT4m3AUwOPF7n5B10bp4BPJnksyVy/7fur6iuw/EMJeHm/fVjctvXvr2zX+I0zNje2qapngSXgZRs28m46nuTz/fKK576SN1YToP81+auAT+NxNfFWxAs8tmZSV5Pi1f4KcxmOdvxkVb0aOAj8RpLX3uS1w+JmPNu3ntgYt431PuAHgR8BvgL8Sb/dWLUsyYuAvwF+u6r+82YvXaXNWN1iq8TLY2tGdTUpXgR2DDzeDlxraSydVlXX+v9eB/6W5dKWr/a/bqL/7/X+y4fFbbF/f2W7xm+csbmxTZIXAFsYvQRAz6OqvlpV36yqbwF/yfKxBcaqVUm+l+UE68NV9VC/2eNqQq0WL4+t2dXVpPgcsDfJ7iSbWS5uP93ymDonye1JXvzcfeBngQssx+Jt/Ze9Dfi7/v3TwJH+2bq7gb3AZ/pfN34jyY/1a7F+eWAbjdc4YzPY11uBf+jX22kMnkuy+n6e5WMLjFVr+v+v7wcuVdWfDjzlcTWBhsXLY2uGtX2mX1s34A0sn0n6JeBdbY+nizeWV//4XP928bk4sFxP9Sngif6/Lx3Y5l39mF1mYIUJoMfyD6YvAe+lf2Eab43i8wDLXw3+H8uzGXePMzbAC4G/ZvlklM8Ar2z7PU/rbUisPgR8Afg8y794X2GsWo/TT7H81fjngcf7tzd4XE3m7Sbx8tia0ZtXtJMkSVLndbV8QpIkSbrBpFiSJEmdZ1IsSZKkzjMpliRJUueZFEuSJKnzTIolSZLUeSbFkiRJ6jyTYkmSJHXe/wNW2wNzU9BOQQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -932,22 +1046,33 @@
     }
    ],
    "source": [
-    "df2 = df[df['start_year'].isin([2008,2006,2007,2004,2005,2003])]\n",
+    "df2 = df[df['start_year'].isin([2008,2007,2006,2004,2005,2003,2002])]\n",
     "\n",
     "fig = plt.figure(figsize=(12,3))\n",
     "ax = fig.add_subplot(111)\n",
     "plt.hist(df2.raw_value, bins=200)\n",
-    "ax.set_yscale('log')"
+    "ax.set_yscale('log')\n",
+    "df2.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 152,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOhUlEQVR4nO3dX4xtZ1kH4N9r+WcAR6EHQ/rHtk5D0hgDOKkYDTGRaEszFpXE1gvRND0hWqMXXpRgFC+MxUQviBVzDA1oSAsiak8oAaKS3hDKKRZoU2sPWNJDCS0SR/RCBF8vZhd2T2fO2TN771l7Zj1PsnP2fLPXmm/Wd9ae33zzfmtVdwcAAMbsu4buAAAADE0oBgBg9IRiAABGTygGAGD0hGIAAEZPKAYAYPSeM3QHkuTCCy/syy67bOhuAABwxN1///1f7e5jZ7cPGoqrajPJ5vr6ek6dOjVkVwAAGIGq+uJO7YOWT3T3ye4+vra2NmQ3AAAYOTXFAACMnlAMAMDoDRqKq2qzqk5sbW0N2Q0AAEZOTTEAAKO3Epdkg51cduuHdmx/7LbrDrgnAMBRJxRz6EyH5emAvFs7AMD5VHcP3YdsbGy06xQfTXsNsLvNDs9DQAYAnlZV93f3xtntZopZuN2C7TICLwDAIgw6Uzx1R7ubH3300cH6wfwOY+A1gwwA47PbTLGrTwAAMHrKJ9gTi9kAgKNIKGbfDmPJxDQBHwB4mlAMEZABYOwGrSkGAIBVYKaY8zrsZRLLYnYZAI6OQUPx1CXZhuwGPIOwCwDjM2go7u6TSU5ubGzcPGQ/eCYzw9/hWADAOCifgAUwuwwAh5tQDAdEcAaA1SUUw4IJvwBw+AjFJFE7uyyOKwAcDq5TDADA6JkpHjGzmAAA28wUAwAwemaKYWAW5gHA8NzRbmSUTAAAPJs72sEA/HICAKtFTTEAAKOnphhWyG71xXttBwD2xkwxAACjZ6YYVpS6YwA4OELxCAhXR4vxBIDFE4qPKMEJAGB2aooBABg9oRgAgNETigEAGD01xXBE7FZH7vrFAHB+QjEccW7wAQDnt5RQXFVvSHJdkpclub27P7qMrwPsjYAMADubuaa4qu6oqier6sGz2q+pqkeq6nRV3Zok3f133X1zkl9J8osL7TEAACzYXhbavTvJNdMNVXVBktuTXJvkqiQ3VtVVUy/5ncnnAQBgZc0cirv73iRfO6v56iSnu/sL3f2NJHclub62vT3Jh7v70zvtr6qOV9Wpqjr11FNP7bf/AAAwt3kvyXZRksenPj4zafuNJK9L8saqevNOG3b3ie7e6O6NY8eOzdkNAADYv3kX2tUObd3d70jyjjn3zR65tTMAwP7MG4rPJLlk6uOLkzwx68ZVtZlkc319fc5uAHvlShQA8B3zhuJPJbmyqi5P8qUkNyT5pVk37u6TSU5ubGzcPGc/gDkIyACM3cyhuKruTPKTSS6sqjNJfq+731VVtyT5SJILktzR3Q8tpafsSMkEAMD8Zg7F3X3jLu33JLlnP19c+QQAAKtg3qtPzKW7T3b38bW1tSG7AQDAyC3lNs/A4aW+GIAxGjQUK5/YH3XEAACLNWgodvUJWG1mjQEYC+UTwJ4JywAcNYMutAMAgFWgphiYy9k17maOATiM1BQfEhbXAQAsj5piYCb7+cVM7TEAh4WaYgAARm/QUFxVm1V1Ymtra8huAAAwcmqKgYVS/w7AYaR8AgCA0bPQDjgQFt0BsMrMFAMAMHoW2gEAMHoW2q0wC5YAAA6G8gkAAEZPKAYAYPSEYgAARk8oBgBg9IRiAABGb9CrT1TVZpLN9fX1IbsBHLDdrqziph4ADMUl2YCV4a53AAxF+QQAAKMnFAMAMHpCMQAAoycUAwAweoMutOPZdluVDwDA8gjFwEqa5UoUrlYBwKIonwAAYPTMFAOHihIjAJZh0JniqtqsqhNbW1tDdgMAgJEbNBR398nuPr62tjZkNwAAGDk1xQAAjJ5QDADA6FloNxCXkoLZWVwHwLKZKQYAYPSEYgAARk8oBgBg9IRiAABGz0K7FWAREQDAsMwUAwAwekIxAACjp3ziACmTgOVZ9rW/XVsc4Ghb+ExxVV1RVe+qqg8set8AALAMM4Xiqrqjqp6sqgfPar+mqh6pqtNVdWuSdPcXuvumZXQWAACWYdaZ4ncnuWa6oaouSHJ7kmuTXJXkxqq6aqG9AwCAAzBTKO7ue5N87azmq5OcnswMfyPJXUmuX3D/AABg6eZZaHdRksenPj6T5Eer6qVJ/iDJq6rqLd39hzttXFXHkxxPkksvvXSObgDMZq+L5WZZHGsBHsDRME8orh3aurv/Pcmbz7dxd59IciJJNjY2eo5+AADAXOa5+sSZJJdMfXxxkif2soOq2qyqE1tbW3N0AwAA5jNPKP5Ukiur6vKqel6SG5LcvZcddPfJ7j6+trY2RzcAAGA+s16S7c4kn0jyiqo6U1U3dfc3k9yS5CNJHk7y/u5+aHldBQCA5Zippri7b9yl/Z4k9+z3i1fVZpLN9fX1/e4C4FncPRKAvVr4He32QvkEAACrYNBQDAAAq2CeS7LNTfkEsGqUXgCMk/IJAABGT/kEAACjJxQDADB6aoqBUZquHX7stusG7AkAq0BNMQAAo6d8AgCA0ROKAQAYPaEYAIDRs9AO4IDtdoMQC/4AhmOhHQAAo6d8AgCA0ROKAQAYPaEYAIDRs9BuCXZbRAOspmWcs94HAA4XC+0AABg95RMAAIyeUAwAwOgJxQAAjJ5QDADA6AnFAACMnkuyASzIvJdhm97+sduuW8i28+wTYExckg0AgNFTPgEAwOgJxQAAjJ5QDADA6AnFAACMnlAMAMDoCcUAAIyeUAwAwOgJxQAAjJ472s3BnaJgnOa9c92ivt6i7nq37G1hL/xfWw7H9fzc0Q4AgNFTPgEAwOgJxQAAjJ5QDADA6AnFAACMnlAMAMDoCcUAAIyeUAwAwOgJxQAAjJ5QDADA6AnFAACMnlAMAMDoPWfRO6yqFyb5syTfSPLx7n7vor8GAAAs0kwzxVV1R1U9WVUPntV+TVU9UlWnq+rWSfPPJ/lAd9+c5GcX3F8AAFi4Wcsn3p3kmumGqrogye1Jrk1yVZIbq+qqJBcneXzysm8tppsAALA8M5VPdPe9VXXZWc1XJznd3V9Ikqq6K8n1Sc5kOxg/kHOE7qo6nuR4klx66aV77fdCXHbrh57x8WO3XTfT6/b7GoBZzfO+s9f3o+nXT78PztOH3faz2/vsfvq0177O8x4/a7/3a9YxW3Y/ZjHP2Oy1//v5Ob3Kx+io2ev3uerHZZ6FdhflOzPCyXYYvijJB5P8QlW9M8nJ3Tbu7hPdvdHdG8eOHZujGwAAMJ95FtrVDm3d3f+d5Ffn2C8AAByoeWaKzyS5ZOrji5M8sZcdVNVmVZ3Y2tqaoxsAADCfeULxp5JcWVWXV9XzktyQ5O697KC7T3b38bW1tTm6AQAA85n1kmx3JvlEkldU1Zmquqm7v5nkliQfSfJwkvd390PL6yoAACzHrFefuHGX9nuS3LPfL15Vm0k219fX97sLAACY26C3eVY+AQDAKqjuHroPqaqnknxx6H4cIRcm+erQneDbjMdqMR6rw1isFuOxWozH8vxAdz/resArEYpZrKo61d0bQ/eDbcZjtRiP1WEsVovxWC3G4+ANWj4BAACrQCgGAGD0hOKj6cTQHeAZjMdqMR6rw1isFuOxWozHAVNTDADA6JkpBgBg9ITiQ6KqHquqz1XVA1V1atL2kqr6WFU9Ovn3+6Ze/5aqOl1Vj1TVz0y1/8hkP6er6h1VVUN8P4dNVd1RVU9W1YNTbQs7/lX1/Kp636T9k1V12UF+f4fNLuPxtqr60uQceaCqXj/1OeOxJFV1SVX9U1U9XFUPVdVvTtqdHwM4x3g4PwZQVS+oqvuq6jOT8fj9SbvzYxV1t8cheCR5LMmFZ7X9UZJbJ89vTfL2yfOrknwmyfOTXJ7k80kumHzuviQ/lqSSfDjJtUN/b4fhkeS1SV6d5MFlHP8kv5bkzyfPb0jyvqG/51V+7DIeb0vy2zu81ngsdyxenuTVk+cvTvKvk2Pu/Fit8XB+DDMeleRFk+fPTfLJJK9xfqzmw0zx4XZ9kvdMnr8nyRum2u/q7v/p7n9LcjrJ1VX18iTf092f6O2z5y+ntuEcuvveJF87q3mRx396Xx9I8lNm8Xe3y3jsxngsUXd/ubs/PXn+9SQPJ7kozo9BnGM8dmM8lqi3/dfkw+dOHh3nx0oSig+PTvLRqrq/qo5P2r6/u7+cbL8RJnnZpP2iJI9PbXtm0nbR5PnZ7ezPIo//t7fp7m8m2Ury0qX1/Oi6pao+OymvePrPkcbjgEz+bPuqbM+GOT8GdtZ4JM6PQVTVBVX1QJInk3ysu50fK0ooPjx+vLtfneTaJL9eVa89x2t3+g2xz9HOYu3n+Bub+b0zyQ8meWWSLyf540m78TgAVfWiJH+T5Le6+z/P9dId2ozHgu0wHs6PgXT3t7r7lUkuzvas7w+d4+XGY0BC8SHR3U9M/n0yyd8muTrJVyZ/Usnk3ycnLz+T5JKpzS9O8sSk/eId2tmfRR7/b29TVc9JspbZywNI0t1fmfzw+b8kf5HtcyQxHktXVc/NdgB7b3d/cNLs/BjITuPh/Bhed/9Hko8nuSbOj5UkFB8CVfXCqnrx08+T/HSSB5PcneRNk5e9KcnfT57fneSGyYrUy5NcmeS+yZ9ovl5Vr5nUG/3y1Dbs3SKP//S+3pjkHyd1Y8zo6R8wEz+X7XMkMR5LNTl270rycHf/ydSnnB8D2G08nB/DqKpjVfW9k+ffneR1Sf4lzo/VNPRKP4/zP5Jcke3VqJ9J8lCSt07aX5rkH5I8Ovn3JVPbvDXbq1YfydQVJpJsZPvN8PNJ/jSTG7h4nHcM7sz2nxz/N9u/ld+0yOOf5AVJ/jrbiyruS3LF0N/zKj92GY+/SvK5JJ/N9g+JlxuPAxmLn8j2n2o/m+SByeP1zo+VGw/nxzDj8cNJ/nly3B9M8ruTdufHCj7c0Q4AgNFTPgEAwOgJxQAAjJ5QDADA6AnFAACMnlAMAMDoCcUAAIyeUAwAwOgJxQAAjN7/AxZIQCz/9KHvAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "(14369, 11)"
+      ]
+     },
+     "execution_count": 152,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADCCAYAAAChUb+JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOZ0lEQVR4nO3dX4xtV10H8O/P8s9AHflTDLltbXEKyQ0xgJOK0RATibbUsag8tD5ITNMbojX64EMJRvHBWIyaSKyYqzSgIS2IiL2hBIhK+kIot1igTa1csKaXEm6ROKIPIrh8mN1yuNy598ycc2bvmfX5JCf3nDVn77PmrLvPfGfNb69drbUAAEDPvmvsDgAAwNiEYgAAuicUAwDQPaEYAIDuCcUAAHRPKAYAoHtPG/PFq2ozyebFF19880te8pIxuwIAQAfuv//+r7TWLjm7vaawTvHGxkY7efLk2N0AAOCQq6r7W2sbZ7crnwAAoHtCMQAA3ROKAQDo3qihuKo2q+r41tbWmN0AAKBzo4bi1tqJ1tqxtbW1MbsBAEDnRl2SDeZ1xa0ffOr+o7ddN2JPAIDDSChmpXYKs/O0L2ufAAAXIhRzKAnIAMBuTOKKduvr62N2gyXbabZ3nlngZb0WAMBuuKIdS3dQgqoZZADoz05XtFM+wVIclCAMAHAuLt4BAED3zBSzK4dpRtjJeADAk4RiiIAMAL1TPgEAQPcsycYFHaaSiWUyuwwAh8eoobi1diLJiY2NjZvH7AffrvcQLOwCQH/UFMN59P4LAgD0QiiGJTC7DAAHm1AM+0RwBoDpEophyZRcAMDBIxSTRJADAPpmnWIAALpnprhjZocBALaZKQYAoHuuaAcjsyoFAIzPFe06o2RiGowDAEyL8gkAALonFAMA0D2rT8CE7La+WD0yACyHUAwHgPALAKslFHfASV0H007jZjwBYPnUFAMA0D0zxYeU2UQAgPmZKQYAoHtCMQAA3ROKAQDonppiOCR2qiO3hBsAXNhKQnFVvS7JdUlemOT21tpHVvE6wIVZ4xgALmzuUFxVdyT56SRnWmsvm2m/JskfJ7koyV+01m5rrX0gyQeq6rlJ/iCJUAwTICADwLntpqb4nUmumW2oqouS3J7k2iRHk9xYVUdnnvKbw9cBAGCy5g7FrbV7k3z1rOark5xqrX2htfb1JHclub62vTXJh1prn1pedwEAYPkWXX3iSJLHZh6fHtp+Nclrkry+qt54rg2r6lhVnayqk0888cSC3QAAgL1b9ES7Okdba629Lcnbzrdha+14kuNJsrGx0RbsB3EVOwCAvVp0pvh0kstmHl+a5PF5N66qzao6vrW1tWA3AABg7xadKf5kkquq6sokX0xyQ5JfmHfj1tqJJCc2NjZuXrAfwC5ZiQIAvmU3S7LdmeTHk7ygqk4n+e3W2juq6pYkH872kmx3tNYeWklPgZURkAHo3dyhuLV24w7t9yS5Zy8vXlWbSTbX19f3sjlRRwwAsAyL1hQvpLV2orV2bG1tbcxuAADQuVFDMQAATMGiJ9otRPkETI/6YgB6NGootvrE3qgjBgBYrlFDMTBtZo0B6IVQDOyasAzAYTPqiXauaAcAwBSoKT4g1BEzVWf/3zRzDMBBpHwCmItfzAA4zIRiYGXUHgNwULh4BwAA3XOiHQAA3XOiHbBUao8BOIiUTwAA0D0n2gH7wkl3AEyZmWIAALrnRDsAALrnRLsJc8ISAMD+UD4BAED3hGIAALonFAMA0D2hGACA7gnFAAB0b9TVJ6pqM8nm+vr6mN0A9tlOK6u4qAcAYxl1pri1dqK1dmxtbW3MbgAA0DmXeQYmw6WgARiLmmIAALonFAMA0D3lExPj0s4AAPtPKAYmSX0xAPtJKAYOLMEZgGVRUwwAQPfMFAMHirp7AFZh1JniqtqsquNbW1tjdgMAgM65oh0AAN1TUwwAQPeEYgAAuudEu5FYSgrm5+Q6AFbNTDEAAN0TigEA6J5QDABA99QUT4B6SQCAcZkpBgCge0IxAADdE4oBAOiemuJ9pHYYVmfVa39bWxzgcFv6THFVvbiq3lFV71v2vgEAYBXmCsVVdUdVnamqB89qv6aqHqmqU1V1a5K01r7QWrtpFZ0FAIBVmHem+J1JrpltqKqLktye5NokR5PcWFVHl9o7AADYB3OF4tbavUm+elbz1UlODTPDX09yV5Lrl9w/AABYuUVOtDuS5LGZx6eT/HBVPT/J7yZ5RVW9qbX2e+fauKqOJTmWJJdffvkC3QCYz25Plpvn5Fgn4AEcDouE4jpHW2ut/XuSN15o49ba8STHk2RjY6Mt0A8AAFjIIqtPnE5y2czjS5M8vpsdVNVmVR3f2tpaoBsAALCYRULxJ5NcVVVXVtUzktyQ5O7d7KC1dqK1dmxtbW2BbgAAwGLmXZLtziQfT/LSqjpdVTe11r6R5JYkH07ycJL3ttYeWl1XAQBgNeaqKW6t3bhD+z1J7tnri1fVZpLN9fX1ve4C4Du4eiQAu7X0K9rthvIJAACmYNRQDAAAU7DIkmwLUz4BTI3SC4A+KZ8AAKB7yicAAOieUAwAQPfUFANdmq0dfvS260bsCQBToKYYAIDuKZ8AAKB7QjEAAN1TUwywz3ZaC1ltM8B41BQDANA95RMAAHRPKAYAoHtCMQAA3ROKAQDontUnVmCnM8uBaVrFMetzAOBgsfoEAADdUz4BAED3hGIAALonFAMA0D2hGACA7gnFAAB0z5JsAEuy6DJss9s/ett1S9l2kX0C9MSSbAAAdE/5BAAA3ROKAQDonlAMAED3hGIAALonFAMA0D2hGACA7gnFAAB0TygGAKB7rmi3AFeKgj4teuW6Zb3esq56t+ptYTf8X1sN7+uFuaIdAADdUz4BAED3hGIAALonFAMA0D2hGACA7gnFAAB0TygGAKB7QjEAAN0TigEA6J5QDABA94RiAAC6JxQDANC9py17h1X17CR/muTrST7WWnv3sl8DAACWaa6Z4qq6o6rOVNWDZ7VfU1WPVNWpqrp1aP65JO9rrd2c5GeW3F8AAFi6ecsn3pnkmtmGqrooye1Jrk1yNMmNVXU0yaVJHhue9s3ldBMAAFZnrvKJ1tq9VXXFWc1XJznVWvtCklTVXUmuT3I628H4gZwndFfVsSTHkuTyyy/fbb+X4opbP/htjx+97bq5nrfX5wDMa5HPnd1+Hs0+f/ZzcJE+7LSfnT5n99Kn3fZ1kc/4efu9V/OO2ar7MY9Fxma3/d/Lz+kpv0eHzW6/z6m/L4ucaHck35oRTrbD8JEk70/y81X19iQndtq4tXa8tbbRWtu45JJLFugGAAAsZpET7eocba219t9JfmmB/QIAwL5aZKb4dJLLZh5fmuTx3eygqjar6vjW1tYC3QAAgMUsEoo/meSqqrqyqp6R5IYkd+9mB621E621Y2trawt0AwAAFjPvkmx3Jvl4kpdW1emquqm19o0ktyT5cJKHk7y3tfbQ6roKAACrMe/qEzfu0H5Pknv2+uJVtZlkc319fa+7AACAhY16mWflEwAATEG11sbuQ6rqiST/NnY/DpEXJPnK2J3gKcZjWozHdBiLaTEe02I8Vuf7W2vfsR7wJEIxy1VVJ1trG2P3g23GY1qMx3QYi2kxHtNiPPbfqOUTAAAwBUIxAADdE4oPp+Njd4BvYzymxXhMh7GYFuMxLcZjn6kpBgCge2aKAQDonlB8QFTVo1X12ap6oKpODm3Pq6qPVtXnhn+fO/P8N1XVqap6pKp+aqb9h4b9nKqqt1VVjfH9HDRVdUdVnamqB2falvb+V9Uzq+o9Q/snquqK/fz+DpodxuMtVfXF4Rh5oKpeO/M147EiVXVZVf1jVT1cVQ9V1a8N7Y6PEZxnPBwfI6iqZ1XVfVX16WE8fmdod3xMUWvN7QDckjya5AVntf1+kluH+7cmeetw/2iSTyd5ZpIrk3w+yUXD1+5L8iNJKsmHklw79vd2EG5JXp3klUkeXMX7n+SXk/zZcP+GJO8Z+3ue8m2H8XhLkt84x3ONx2rH4kVJXjncvzjJvwzvueNjWuPh+BhnPCrJc4b7T0/yiSSvcnxM82am+GC7Psm7hvvvSvK6mfa7Wmv/01r71ySnklxdVS9K8j2ttY+37aPnL2e24Txaa/cm+epZzct8/2f39b4kP2EWf2c7jMdOjMcKtda+1Fr71HD/a0keTnIkjo9RnGc8dmI8Vqht+6/h4dOHW4vjY5KE4oOjJflIVd1fVceGtu9rrX0p2f4gTPLCof1Iksdmtj09tB0Z7p/dzt4s8/1/apvW2jeSbCV5/sp6fnjdUlWfGcornvxzpPHYJ8OfbV+R7dkwx8fIzhqPxPExiqq6qKoeSHImyUdba46PiRKKD44fba29Msm1SX6lql59nuee6zfEdp52lmsv77+xWdzbk/xAkpcn+VKSPxzajcc+qKrnJPmbJL/eWvvP8z31HG3GY8nOMR6Oj5G01r7ZWnt5kkuzPev7svM83XiMSCg+IFprjw//nknyt0muTvLl4U8qGf49Mzz9dJLLZja/NMnjQ/ul52hnb5b5/j+1TVU9Lcla5i8PIElr7cvDD5//S/Ln2T5GEuOxclX19GwHsHe31t4/NDs+RnKu8XB8jK+19h9JPpbkmjg+JkkoPgCq6tlVdfGT95P8ZJIHk9yd5A3D096Q5O+G+3cnuWE4I/XKJFcluW/4E83XqupVQ73RL85sw+4t8/2f3dfrk/zDUDfGnJ78ATP42WwfI4nxWKnhvXtHkodba3808yXHxwh2Gg/Hxziq6pKq+t7h/ncneU2Sf47jY5rGPtPP7cK3JC/O9tmon07yUJI3D+3PT/L3ST43/Pu8mW3enO2zVh/JzAoTSTay/WH4+SR/kuECLm4XHIM7s/0nx//N9m/lNy3z/U/yrCR/ne2TKu5L8uKxv+cp33YYj79K8tkkn8n2D4kXGY99GYsfy/afaj+T5IHh9lrHx+TGw/Exznj8YJJ/Gt73B5P81tDu+JjgzRXtAADonvIJAAC6JxQDANA9oRgAgO4JxQAAdE8oBgCge0IxAADdE4oBAOieUAwAQPf+H2kEMjKxzR7rAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -959,22 +1084,33 @@
     }
    ],
    "source": [
-    "df3 = df[df['start_year'].isin([1997,1998,2001,2000,1999])]\n",
+    "df3 = df[df['start_year'].isin([1997,1998,1999,2001,2000])]\n",
     "\n",
     "fig = plt.figure(figsize=(12,3))\n",
     "ax = fig.add_subplot(111)\n",
     "plt.hist(df3.raw_value, bins=200)\n",
-    "ax.set_yscale('log')"
+    "ax.set_yscale('log')\n",
+    "df3.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 155,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADGCAYAAAA6wP2fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANhUlEQVR4nO3dUYil51kH8P9jQm6KjtKkKknWTdlQCaIoYywqgqAlNawRLZgoiiVk6UUEL3qxInhXzI03hVZZJZRCbSjSapZujd5ILppKNlJrYkxZw5asEZJWGVHBGn282Gk7mezsnjPfOXPOmff3g2HnfOd7z/eeeec757/vPOf9qrsDAAAj+7ZVdwAAAFZNKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4S0lFFfVL1TVH1XVn1fVe5ZxDAAAWJSZQ3FVPV5Vr1XV8/u231dVL1XVpao6myTd/Wfd/UiS30jyywvtMQAALFjNepnnqvqpJP+R5OPd/QO7225K8uUkP5vkSpJnkzzU3f+we//vJ/lEd//t9R771ltv7ZMnTx72OQAAwEyee+65r3b3bfu33zzrA3T301V1ct/me5Nc6u6Xk6SqnkjyQFW9mOSxJJ+7USBOkpMnT+bixYuzdgUAAA6lqr5yre1Ta4pvT/LKnttXdrf9ZpKfSfK+qvrAAR06U1UXq+ri66+/PrEbAABweDPPFB+grrGtu/vDST58vYbdfS7JuSTZ3t6erYYDAACWYOpM8ZUkd+65fUeSVyc+JgAAHKmpofjZJHdX1V1VdUuSB5M8OWvjqjpdVed2dnYmdgMAAA5vniXZPpnkmSTvqqorVfVwd7+R5NEkTyV5McmnuvuFWR+zu89395mtra15+w0AAAszz+oTDx2w/UKSCwvrERwjJ89+9pvfX37s/hX2BAC4Hpd5BgBgeFNXn5ikqk4nOX3q1KlVdgMOZKYXAMaw0pliNcUAAKyDlc4Uw7owIwwAYxOKYUZ7g3NycHjev98ijieoA8ByCcVwSEIrABwfPmgH+yxqpnfWYwjUALB6Kw3F3X0+yfnt7e1HVtkPmOoogjQAsDzKJ2ADmFkGgOUSijn2DgqUZncBgG8QitloAi8AsAg+aAcbTFkFACyGD9rBigm2ALB6yifgmBCuAeDwhGKODXXE1yYsA8CNCcWsleMc4IR2AFhfQjELt6hge1CIPG5hea9ZgvOi9gEAvsXqE6ycAAcArNq3rfLg3X2+u89sbW2tshsAAAxupaEYAADWgZpihqJU41uO84caAWBeQjEM5KD/FAjIAIxOKObQBCmStwZtvwsAbCKhGHgT/9kBYESWZGPjqAsGABbNkmwAAAxP+QQ3tIw/p5vtBQDWiVDMkRGEN4/6YgBGIRQDc/MfHACOG6EYmIkgDMBxJhQzF8EIADiOhGKWSogGADaBUAwsjQ/qAbAphOLBCCks2yx/HfB7CMC6WenFO6rqdFWd29nZWWU3AAAY3Epnirv7fJLz29vbj6yyH8fRUc/EqR0GADaZ8glgoyi9AGAZVlo+AQAA60AoBgBgeMonBqDel3WmHAKAdSAU8xZCNOtAWAbgKAnFJBGEWT6/YwCsMzXFAAAMz0wxsDbMJgOwKkLxwAQQAICrlE8AADA8M8UbzmwvAMB0K50prqrTVXVuZ2dnld0AAGBwKw3F3X2+u89sbW2tshsAAAxOTTEAAMMTigEAGJ4P2gFrzwdKAVg2M8UAAAzPTDGwsfbOIF9+7P4V9gSATWemGACA4Zkp3hBqKmGxzDIDsJeZYgAAhicUAwAwPKEYAIDhCcUAAAxPKAYAYHhCMQAAwxOKAQAYnlAMAMDwXLxjjblgBwDA0TBTDADA8IRiAACGt/Dyiap6Z5LfSbLV3e9b9OMDXMvecqPLj91/w32mtN27zyxtAVh/M80UV9XjVfVaVT2/b/t9VfVSVV2qqrNJ0t0vd/fDy+gsAAAsw6zlEx9Lct/eDVV1U5KPJHlvknuSPFRV9yy0dwAAcARmCsXd/XSSf923+d4kl3Znhr+e5IkkDyy4fwAAsHRTaopvT/LKnttXkvxYVb09yYeS/HBV/XZ3/961GlfVmSRnkuTEiRMTugFwsKNc2nBqfbH6ZIDVmRKK6xrburu/luQDN2rc3eeSnEuS7e3tntAPAACYZMqSbFeS3Lnn9h1JXp3WHQAAOHpTZoqfTXJ3Vd2V5J+TPJjkV+Z5gKo6neT0qVOnJnQD4M2mlEwcdQmDK1cCrIdZl2T7ZJJnkryrqq5U1cPd/UaSR5M8leTFJJ/q7hfmOXh3n+/uM1tbW/P2GwAAFmammeLufuiA7ReSXFhojwAA4Ii5zDMAAMNb+GWe56Gm+K3UF8L6cD4CjGOlM8VqigEAWAfKJwAAGJ5QDADA8NQUAwzIJaUB3kxNMQAAw1M+AQDA8IRiAACGJxQDADA8oRgAgOFZfWINuGoWHD/XO69HWO3hMKtbWBEDWCWrTwAAMDzlEwAADE8oBgBgeEIxAADDE4oBABie1ScAjthRrjgzy7EOWvXhoLbzrgwxdVUJq1IAR8HqEwAADE/5BAAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDxLsi2B5YOAZTnK5dxG5PUbxmVJNgAAhqd8AgCA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8V7QDmNNRXFVulCvXHfQ8j+vzd8U8WF+uaAcAwPCUTwAAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADO/mVR68qk4nOX3q1KlVdmMuJ89+9pvfX37s/iNrC7Au9r6W7TXL69pBbaea5fX1oH2W1acpNvH9YhP7DHutdKa4u89395mtra1VdgMAgMEpnwAAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4QnFAAAMTygGAGB4QjEAAMMTigEAGJ5QDADA8IRiAACGJxQDADA8oRgAgOEJxQAADE8oBgBgeEIxAADDu3nRD1hVb0vy0SRfT/LX3f2JRR8DAAAWaaaZ4qp6vKpeq6rn922/r6peqqpLVXV2d/MvJvnT7n4kyc8vuL8AALBws5ZPfCzJfXs3VNVNST6S5L1J7knyUFXdk+SOJK/s7va/i+kmAAAsz0zlE939dFWd3Lf53iSXuvvlJKmqJ5I8kORKrgbjL+Y6obuqziQ5kyQnTpyYt98LcfLsZ990+/Jj98+03422H+bYAJvuKF7X5j3Gsl+nD3rfWOSx9t63jOPN+943bx8OOtYs269nlsdahqM81jqa8vzX/Wc35YN2t+dbM8LJ1TB8e5JPJ/mlqvqDJOcPatzd57p7u7u3b7vttgndAACAaaZ80K6usa27+z+TvH/C4wIAwJGaMlN8Jcmde27fkeTVad0BAICjNyUUP5vk7qq6q6puSfJgkifneYCqOl1V53Z2diZ0AwAAppl1SbZPJnkmybuq6kpVPdzdbyR5NMlTSV5M8qnufmGeg3f3+e4+s7W1NW+/AQBgYWZdfeKhA7ZfSHJhoT0CAIAj5jLPAAAMr7p71X1IVb2e5CtzNLk1yVeX1B2Wy9htLmO3uYzd5jJ2m8vYra/v6+63rAe8FqF4XlV1sbu3V90P5mfsNpex21zGbnMZu81l7DaP8gkAAIYnFAMAMLxNDcXnVt0BDs3YbS5jt7mM3eYydpvL2G2YjawpBgCARdrUmWIAAFiYtQvFVXVfVb1UVZeq6uw17q+q+vDu/V+qqh+ZtS3LNXHsLlfV31fVF6vq4tH2nBnG7vur6pmq+u+q+uA8bVmeiePmnFuhGcbuV3dfJ79UVZ+vqh+atS3LNXHsnHfrrLvX5ivJTUn+Kck7k9yS5O+S3LNvn59L8rkkleTdSf5m1ra+1nPsdu+7nOTWVT+PEb9mHLt3JPnRJB9K8sF52vpav3Hbvc85t95j9+NJvmv3+/d6r1uPryljt3vbebfGX+s2U3xvkkvd/XJ3fz3JE0ke2LfPA0k+3ld9Icl3VtX3ztiW5ZkydqzWDceuu1/r7meT/M+8bVmaKePGas0ydp/v7n/bvfmFJHfM2palmjJ2rLl1C8W3J3llz+0ru9tm2WeWtizPlLFLkk7yl1X1XFWdWVovuZYp547zbnWm/uydc6sz79g9nKt/ZTtMWxZrytglzru1dvOqO7BPXWPb/uUxDtpnlrYsz5SxS5Kf6O5Xq+odSf6qqv6xu59eaA85yJRzx3m3OlN/9s651Zl57Krqp3M1WP3kvG1Ziiljlzjv1tq6zRRfSXLnntt3JHl1xn1macvyTBm7dPc3/n0tyWdy9U9UHI0p547zbnUm/eydcys109hV1Q8m+eMkD3T31+Zpy9JMGTvn3Zpbt1D8bJK7q+quqrolyYNJnty3z5NJfn13JYN3J9np7n+ZsS3Lc+ixq6q3VdW3J0lVvS3Je5I8f5SdH9yUc8d5tzqH/tk751buhmNXVSeSfDrJr3X3l+dpy1Ideuycd+tvrconuvuNqno0yVO5+gnPx7v7har6wO79f5jkQq6uYnApyX8lef/12q7gaQxpytgl+e4kn6mq5Orv5J90918c8VMY1ixjV1Xfk+Riku9I8n9V9Vu5+onrf3fercaUcUtya5xzKzPj6+XvJnl7ko/ujtMb3b3tvW61poxdvNetPVe0AwBgeOtWPgEAAEdOKAYAYHhCMQAAwxOKAQAYnlAMAMDwhGIAAIYnFAMAMDyhGACA4f0/gihRYoA+tNQAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "(3218, 11)"
+      ]
+     },
+     "execution_count": 155,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsUAAADGCAYAAAA6wP2fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANkUlEQVR4nO3dUYhl910H8O+vCXkpOko3Vclm3ZQJkSCKMsaiIghaNoZxRQtmFcUSsuQhgg99WBF8K+6LL4FWWSWUQk0I0mqWbI2+SB6aSjbS1sSYsoYtWSMkrbKigjH692HHOpns7J4759577p3/5wPDzj33/u/53/nPufc7//2d/6nWWgAAoGfvm7oDAAAwNaEYAIDuCcUAAHRPKAYAoHtCMQAA3ROKAQDonlAMAED3hGIAALq3kFBcVT9fVX9YVX9WVR9ZxD4AAGBeBofiqnq8qt6sqpf2bD9RVa9W1aWqOpMkrbU/ba09nOTXk/zSXHsMAABzVkMv81xVP5nk35J8prX2/TvbbknytSQ/k+RKkheSnGqt/d3O/b+X5LOttb+50XMfOXKkHT9+/KCvAQAABnnxxRe/0Vq7fe/2W4c+QWvtuao6vmfzfUkutdZeS5KqejLJyap6JcnZJF+4WSBOkuPHj+fixYtDuwIAAAdSVV+/3vaxNcV3JHl91+0rO9t+I8lPJ/loVT2yT4dOV9XFqrr41ltvjewGAAAc3OCZ4n3Udba11tpjSR67UcPW2rkk55Jka2trWA0HAAAswNiZ4itJ7tx1+2iSN0Y+JwAALNXYUPxCkrur6q6qui3Jg0meHtq4qrar6tzVq1dHdgMAAA5uliXZnkjyfJJ7qupKVT3UWnsnyaNJnk3ySpKnWmsvD33O1tr51trpjY2NWfsNAABzM8vqE6f22X4hyYW59QgOkeNnnvnW95fPPjBhTwCAG3GZZwAAujdpKFZTDADAKhi7JNsorbXzSc5vbW09PGU/YD/KHwCgD8onAADo3qQzxXAY7Z5dBgDWg1AMGVYmsTfsLrqcQukGACyPE+0AAOieE+3ggMaUSZgFBoDVonwC9ljFmmAhGgAWSyjm0NsvUK5i+AUApiEUcygJvADALCYNxVW1nWR7c3Nzym6wxpQVAADz4EQ7mNiYYO+PAgCYD1e0AwCge2qKOTR6ryMeckKh2WQAuD4zxQAAdM9MMXM3rxrZ3Q7DDGfvM9kAsMqsPgFrRrgGgPmz+gSTGxLyeqmLnVfgFZwBYDZqigEA6J5QDABA95xoR1d6LysY8voPc3kKAOzHTDEAAN0zU8yB9XLyW29mHde9s89+FwBYR5POFFfVdlWdu3r16pTdAACgc5OG4tba+dba6Y2NjSm7AQBA55RPcFOrVibR+8lyAMD8CcVMQrBdD6v2BxEALIpQzNIIwoeHsQTgsBGKgUEEYQAOM6GYmQhGAMBhJBSzUEI0ALAOhGJgYZyoB8C6EIo7I6SwCvweArBqJg3FVbWdZHtzc3PKbgBzpGQGgHU0aShurZ1Pcn5ra+vhKftxGC17Jk4QAgDWmfIJYK0ovQBgEd43dQcAAGBqQjEAAN1TPtEB9b4AADcmFPMeQjTLtF+NsNphAJZJKAaWwh9bAKwyNcUAAHTPTDFJzOKxGvweAjAVobhjAggAwDXKJwAA6J6Z4kPEzC8AwMFMGoqrajvJ9ubm5pTdWGuCMADAeJOWT7TWzrfWTm9sbEzZDQAAOqemGACA7gnFAAB0z4l2wMpTOw/AopkpBgCge2aKgbW1ewb58tkHJuwJAOvOTDEAAN0zU7wm1FTCfJllBmA3M8UAAHRPKAYAoHtCMQAA3ROKAQDonlAMAED3hGIAALonFAMA0D2hGACA7rl4xwpzwQ4AgOUwUwwAQPeEYgAAujf38omq+lCS306y0Vr76LyfH+B6dpcbXT77wE0fM6bt7scMaQvA6hs0U1xVj1fVm1X10p7tJ6rq1aq6VFVnkqS19lpr7aFFdBYAABZhaPnEp5Oc2L2hqm5J8skk9ye5N8mpqrp3rr0DAIAlGBSKW2vPJfnnPZvvS3JpZ2b47SRPJjk55/4BAMDCjakpviPJ67tuX0nyo1X1gSSfSPJDVfVbrbXfvV7jqjqd5HSSHDt2bEQ3APa3zKUNx9YXq08GmM6YUFzX2dZaa99M8sjNGrfWziU5lyRbW1ttRD8AAGCUMUuyXUly567bR5O8Ma47AACwfGNmil9IcndV3ZXkH5M8mOSXZ3mCqtpOsr25uTmiGwDvNqZkYtklDK5cCbAahi7J9kSS55PcU1VXquqh1to7SR5N8mySV5I81Vp7eZadt9bOt9ZOb2xszNpvAACYm0Ezxa21U/tsv5Dkwlx7BAAAS+YyzwAAdG/ul3mehZri91JfCKvD8QjQj0lnitUUAwCwCpRPAADQPaEYAIDuqSkG6JBLSgO8m5piAAC6p3wCAIDuCcUAAHRPKAYAoHtCMQAA3bP6xApw1Sw4fG50XPew2sNBVrewIgYwJatPAADQPeUTAAB0TygGAKB7QjEAAN0TigEA6J7VJwCWbJkrzgzZ136rPuzXdtaVIcauKmFVCmAZrD4BAED3lE8AANA9oRgAgO4JxQAAdE8oBgCge0IxAADdsyTbAlg+CFiGZS7t1gvv39AvS7IBANA95RMAAHRPKAYAoHtCMQAA3ROKAQDonlAMAED3hGIAALonFAMA0D2hGACA7rmiHcCMlnEluV6uVrff6zysr98V82B1uaIdAADdUz4BAED3hGIAALonFAMA0D2hGACA7gnFAAB0TygGAKB7QjEAAN0TigEA6J5QDABA94RiAAC6JxQDANC9W6fceVVtJ9ne3NycshszOX7mmW99f/nsA0trC7Aqdr+X7TbkfW2/tmMNeX/d7zGL6tMY6/h5sY59ht0mnSlurZ1vrZ3e2NiYshsAAHRO+QQAAN0TigEA6J5QDABA94RiAAC6JxQDANA9oRgAgO4JxQAAdE8oBgCge0IxAADdE4oBAOieUAwAQPeEYgAAuicUAwDQPaEYAIDuCcUAAHRPKAYAoHtCMQAA3ROKAQDo3q3zfsKqen+STyV5O8lftdY+O+99AADAPA2aKa6qx6vqzap6ac/2E1X1alVdqqozO5t/IcmftNYeTvJzc+4vAADM3dDyiU8nObF7Q1XdkuSTSe5Pcm+SU1V1b5KjSV7fedh/z6ebAACwOIPKJ1prz1XV8T2b70tyqbX2WpJU1ZNJTia5kmvB+Mu5QeiuqtNJTifJsWPHZu33XBw/88y7bl8++8Cgx91s+0H2DbDulvG+Nus+Fv0+vd/nxjz3tfu+Rexv1s++Wfuw376GbL+RIc+1CMvc1yoa8/pX/Wc35kS7O/L/M8LJtTB8R5LPJfnFqvr9JOf3a9xaO9da22qtbd1+++0jugEAAOOMOdGurrOttdb+PcnHRjwvAAAs1ZiZ4itJ7tx1+2iSN8Z1BwAAlm9MKH4hyd1VdVdV3ZbkwSRPz/IEVbVdVeeuXr06ohsAADDO0CXZnkjyfJJ7qupKVT3UWnsnyaNJnk3ySpKnWmsvz7Lz1tr51trpjY2NWfsNAABzM3T1iVP7bL+Q5MJcewQAAEvmMs8AAHSvWmtT9yFV9VaSr8/Q5EiSbyyoOyyWsVtfxm59Gbv1ZezWl7FbXd/bWnvPesArEYpnVVUXW2tbU/eD2Rm79WXs1pexW1/Gbn0Zu/WjfAIAgO4JxQAAdG9dQ/G5qTvAgRm79WXs1pexW1/Gbn0ZuzWzljXFAAAwT+s6UwwAAHOzcqG4qk5U1atVdamqzlzn/qqqx3bu/2pV/fDQtizWyLG7XFV/W1VfrqqLy+05A8bu+6rq+ar6z6r6+CxtWZyR4+aYm9CAsfuVnffJr1bVF6vqB4e2ZbFGjp3jbpW11lbmK8ktSf4hyYeS3JbkK0nu3fOYn03yhSSV5MNJ/npoW1+rOXY7911OcmTq19Hj18Cx+2CSH0nyiSQfn6Wtr9Ubt537HHOrPXY/luQ7d76/32fdanyNGbud2467Ff5atZni+5Jcaq291lp7O8mTSU7ueczJJJ9p13wpyXdU1fcMbMvijBk7pnXTsWutvdlaeyHJf83aloUZM25Ma8jYfbG19i87N7+U5OjQtizUmLFjxa1aKL4jyeu7bl/Z2TbkMUPasjhjxi5JWpK/qKoXq+r0wnrJ9Yw5dhx30xn7s3fMTWfWsXso1/6X7SBtma8xY5c47lbarVN3YI+6zra9y2Ps95ghbVmcMWOXJD/eWnujqj6Y5C+r6u9ba8/NtYfsZ8yx47ibztifvWNuOoPHrqp+KteC1U/M2paFGDN2ieNupa3aTPGVJHfuun00yRsDHzOkLYszZuzSWvu/f99M8vlc+y8qlmPMseO4m86on71jblKDxq6qfiDJHyU52Vr75ixtWZgxY+e4W3GrFopfSHJ3Vd1VVbcleTDJ03se83SSX9tZyeDDSa621v5pYFsW58BjV1Xvr6pvS5Kqen+SjyR5aZmd79yYY8dxN50D/+wdc5O76dhV1bEkn0vyq621r83SloU68Ng57lbfSpVPtNbeqapHkzyba2d4Pt5ae7mqHtm5/w+SXMi1VQwuJfmPJB+7UdsJXkaXxoxdku9K8vmqSq79Tv5xa+3Pl/wSujVk7Krqu5NcTPLtSf6nqn4z1864/lfH3TTGjFuSI3HMTWbg++XvJPlAkk/tjNM7rbUtn3XTGjN28Vm38lzRDgCA7q1a+QQAACydUAwAQPeEYgAAuicUAwDQPaEYAIDuCcUAAHRPKAYAoHtCMQAA3ftfgTJKWSyRyPUAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 864x216 with 1 Axes>"
       ]
@@ -991,7 +1127,9 @@
     "fig = plt.figure(figsize=(12,3))\n",
     "ax = fig.add_subplot(111)\n",
     "plt.hist(df4.raw_value, bins=200)\n",
-    "ax.set_yscale('log')"
+    "ax.set_yscale('log')\n",
+    "\n",
+    "df4.shape"
    ]
   },
   {
@@ -1003,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 156,
    "metadata": {},
    "outputs": [
     {
@@ -1138,7 +1276,7 @@
        "152959     2701.6     2270.0      2011.0  "
       ]
      },
-     "execution_count": 62,
+     "execution_count": 156,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1151,7 +1289,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 157,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(9232, 11)"
+      ]
+     },
+     "execution_count": 157,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df1[df1.measure_name=='Sexually transmitted infections'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 158,
    "metadata": {},
    "outputs": [
     {
@@ -1204,6 +1362,20 @@
        "      <td>2003.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>27334</th>\n",
+       "      <td>SD</td>\n",
+       "      <td>Shannon County</td>\n",
+       "      <td>46.0</td>\n",
+       "      <td>113.0</td>\n",
+       "      <td>Premature Death</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>311.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>27178.700</td>\n",
+       "      <td>46113.0</td>\n",
+       "      <td>2002.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>27335</th>\n",
        "      <td>SD</td>\n",
        "      <td>Shannon County</td>\n",
@@ -1245,20 +1417,6 @@
        "      <td>38085.0</td>\n",
        "      <td>2007.0</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22929</th>\n",
-       "      <td>ND</td>\n",
-       "      <td>Sioux County</td>\n",
-       "      <td>38.0</td>\n",
-       "      <td>85.0</td>\n",
-       "      <td>Premature Death</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>91.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>25017.980</td>\n",
-       "      <td>38085.0</td>\n",
-       "      <td>2005.0</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -1266,20 +1424,20 @@
       "text/plain": [
        "      state           county  state_code  county_code     measure_name  \\\n",
        "27258    SD  Mellette County        46.0         95.0  Premature Death   \n",
+       "27334    SD   Shannon County        46.0        113.0  Premature Death   \n",
        "27335    SD   Shannon County        46.0        113.0  Premature Death   \n",
        "27336    SD   Shannon County        46.0        113.0  Premature Death   \n",
        "22931    ND     Sioux County        38.0         85.0  Premature Death   \n",
-       "22929    ND     Sioux County        38.0         85.0  Premature Death   \n",
        "\n",
        "       measure_id  numerator  denominator  raw_value  fips_code  start_year  \n",
        "27258         1.0       54.0          NaN  28433.300    46095.0      2003.0  \n",
+       "27334         1.0      311.0          NaN  27178.700    46113.0      2002.0  \n",
        "27335         1.0      311.0          NaN  26489.600    46113.0      2003.0  \n",
        "27336         1.0      307.0          NaN  26281.428    46113.0      2004.0  \n",
-       "22931         1.0      105.0          NaN  25367.021    38085.0      2007.0  \n",
-       "22929         1.0       91.0          NaN  25017.980    38085.0      2005.0  "
+       "22931         1.0      105.0          NaN  25367.021    38085.0      2007.0  "
       ]
      },
-     "execution_count": 63,
+     "execution_count": 158,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1292,7 +1450,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 159,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(21083, 11)"
+      ]
+     },
+     "execution_count": 159,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df2[df2.measure_name=='Premature Death'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
    "metadata": {},
    "outputs": [
     {
@@ -1427,7 +1605,7 @@
        "26940    46017.0      1998.0  "
       ]
      },
-     "execution_count": 64,
+     "execution_count": 160,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1440,7 +1618,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 161,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(14369, 11)"
+      ]
+     },
+     "execution_count": 161,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df3[df3.measure_name=='Premature Death'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
    "metadata": {},
    "outputs": [
     {
@@ -1568,7 +1766,7 @@
        "70747        23.0     1034.0       4466.0   0.231527    72001.0      2012.0  "
       ]
      },
-     "execution_count": 66,
+     "execution_count": 162,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1583,19 +1781,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sexually transmitted infections are found Alaska, "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### <b>Top five measures with the higest raw_value in different groups"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 163,
    "metadata": {},
    "outputs": [
     {
@@ -1634,73 +1825,73 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>257226</th>\n",
-       "      <td>TN</td>\n",
-       "      <td>Shelby County</td>\n",
-       "      <td>47.0</td>\n",
-       "      <td>157.0</td>\n",
+       "      <th>245430</th>\n",
+       "      <td>IN</td>\n",
+       "      <td>Boone County</td>\n",
+       "      <td>18.0</td>\n",
+       "      <td>11.0</td>\n",
        "      <td>Violent crime rate</td>\n",
        "      <td>43.0</td>\n",
-       "      <td>11742.333330</td>\n",
-       "      <td>924734.66670</td>\n",
-       "      <td>1269.805681</td>\n",
-       "      <td>47157.0</td>\n",
+       "      <td>9.500000</td>\n",
+       "      <td>40952.000000</td>\n",
+       "      <td>23.197890</td>\n",
+       "      <td>18011.0</td>\n",
        "      <td>2009.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>254638</th>\n",
-       "      <td>OK</td>\n",
-       "      <td>Adair County</td>\n",
-       "      <td>40.0</td>\n",
-       "      <td>1.0</td>\n",
+       "      <th>247672</th>\n",
+       "      <td>KY</td>\n",
+       "      <td>Lewis County</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>135.0</td>\n",
        "      <td>Violent crime rate</td>\n",
        "      <td>43.0</td>\n",
-       "      <td>76.000000</td>\n",
-       "      <td>22546.00000</td>\n",
-       "      <td>337.088619</td>\n",
-       "      <td>40001.0</td>\n",
+       "      <td>9.000000</td>\n",
+       "      <td>13877.000000</td>\n",
+       "      <td>64.855516</td>\n",
+       "      <td>21135.0</td>\n",
        "      <td>2009.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>254580</th>\n",
-       "      <td>OH</td>\n",
-       "      <td>Van Wert County</td>\n",
-       "      <td>39.0</td>\n",
-       "      <td>161.0</td>\n",
+       "      <th>247732</th>\n",
+       "      <td>KY</td>\n",
+       "      <td>Magoffin County</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>153.0</td>\n",
        "      <td>Violent crime rate</td>\n",
        "      <td>43.0</td>\n",
-       "      <td>36.666667</td>\n",
-       "      <td>28748.66667</td>\n",
-       "      <td>127.542147</td>\n",
-       "      <td>39161.0</td>\n",
+       "      <td>4.666667</td>\n",
+       "      <td>13304.000000</td>\n",
+       "      <td>35.077170</td>\n",
+       "      <td>21153.0</td>\n",
        "      <td>2009.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>254587</th>\n",
-       "      <td>OH</td>\n",
-       "      <td>Vinton County</td>\n",
-       "      <td>39.0</td>\n",
-       "      <td>163.0</td>\n",
+       "      <th>247725</th>\n",
+       "      <td>KY</td>\n",
+       "      <td>Madison County</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>151.0</td>\n",
        "      <td>Violent crime rate</td>\n",
        "      <td>43.0</td>\n",
-       "      <td>16.666667</td>\n",
-       "      <td>13417.66667</td>\n",
-       "      <td>124.214344</td>\n",
-       "      <td>39163.0</td>\n",
+       "      <td>168.666667</td>\n",
+       "      <td>83345.666670</td>\n",
+       "      <td>202.370049</td>\n",
+       "      <td>21151.0</td>\n",
        "      <td>2009.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>254593</th>\n",
-       "      <td>OH</td>\n",
-       "      <td>Warren County</td>\n",
-       "      <td>39.0</td>\n",
-       "      <td>165.0</td>\n",
+       "      <th>247718</th>\n",
+       "      <td>KY</td>\n",
+       "      <td>McLean County</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>149.0</td>\n",
        "      <td>Violent crime rate</td>\n",
        "      <td>43.0</td>\n",
-       "      <td>154.666667</td>\n",
-       "      <td>208683.33330</td>\n",
-       "      <td>74.115486</td>\n",
-       "      <td>39165.0</td>\n",
+       "      <td>2.666667</td>\n",
+       "      <td>9597.333333</td>\n",
+       "      <td>27.785496</td>\n",
+       "      <td>21149.0</td>\n",
        "      <td>2009.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1709,28 +1900,28 @@
       ],
       "text/plain": [
        "       state           county  state_code  county_code        measure_name  \\\n",
-       "257226    TN    Shelby County        47.0        157.0  Violent crime rate   \n",
-       "254638    OK     Adair County        40.0          1.0  Violent crime rate   \n",
-       "254580    OH  Van Wert County        39.0        161.0  Violent crime rate   \n",
-       "254587    OH    Vinton County        39.0        163.0  Violent crime rate   \n",
-       "254593    OH    Warren County        39.0        165.0  Violent crime rate   \n",
+       "245430    IN     Boone County        18.0         11.0  Violent crime rate   \n",
+       "247672    KY     Lewis County        21.0        135.0  Violent crime rate   \n",
+       "247732    KY  Magoffin County        21.0        153.0  Violent crime rate   \n",
+       "247725    KY   Madison County        21.0        151.0  Violent crime rate   \n",
+       "247718    KY    McLean County        21.0        149.0  Violent crime rate   \n",
        "\n",
-       "        measure_id     numerator   denominator    raw_value  fips_code  \\\n",
-       "257226        43.0  11742.333330  924734.66670  1269.805681    47157.0   \n",
-       "254638        43.0     76.000000   22546.00000   337.088619    40001.0   \n",
-       "254580        43.0     36.666667   28748.66667   127.542147    39161.0   \n",
-       "254587        43.0     16.666667   13417.66667   124.214344    39163.0   \n",
-       "254593        43.0    154.666667  208683.33330    74.115486    39165.0   \n",
+       "        measure_id   numerator   denominator   raw_value  fips_code  \\\n",
+       "245430        43.0    9.500000  40952.000000   23.197890    18011.0   \n",
+       "247672        43.0    9.000000  13877.000000   64.855516    21135.0   \n",
+       "247732        43.0    4.666667  13304.000000   35.077170    21153.0   \n",
+       "247725        43.0  168.666667  83345.666670  202.370049    21151.0   \n",
+       "247718        43.0    2.666667   9597.333333   27.785496    21149.0   \n",
        "\n",
        "        start_year  \n",
-       "257226      2009.0  \n",
-       "254638      2009.0  \n",
-       "254580      2009.0  \n",
-       "254587      2009.0  \n",
-       "254593      2009.0  "
+       "245430      2009.0  \n",
+       "247672      2009.0  \n",
+       "247732      2009.0  \n",
+       "247725      2009.0  \n",
+       "247718      2009.0  "
       ]
      },
-     "execution_count": 68,
+     "execution_count": 163,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1743,7 +1934,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 164,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2955, 11)"
+      ]
+     },
+     "execution_count": 164,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df1[df1.measure_name=='Violent crime rate'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 165,
    "metadata": {},
    "outputs": [
     {
@@ -1782,96 +1993,96 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>251382</th>\n",
-       "      <td>MT</td>\n",
-       "      <td>Musselshell County</td>\n",
-       "      <td>30.0</td>\n",
-       "      <td>65.0</td>\n",
-       "      <td>Violent crime rate</td>\n",
-       "      <td>43.0</td>\n",
-       "      <td>19.000000</td>\n",
-       "      <td>4533.50000</td>\n",
-       "      <td>419.102239</td>\n",
-       "      <td>30065.0</td>\n",
-       "      <td>2003.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>255671</th>\n",
-       "      <td>PA</td>\n",
-       "      <td>Juniata County</td>\n",
-       "      <td>42.0</td>\n",
+       "      <th>249671</th>\n",
+       "      <td>MN</td>\n",
+       "      <td>Kandiyohi County</td>\n",
+       "      <td>27.0</td>\n",
        "      <td>67.0</td>\n",
        "      <td>Violent crime rate</td>\n",
        "      <td>43.0</td>\n",
-       "      <td>20.666667</td>\n",
-       "      <td>23216.66667</td>\n",
-       "      <td>89.016511</td>\n",
-       "      <td>42067.0</td>\n",
-       "      <td>2006.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>255664</th>\n",
-       "      <td>PA</td>\n",
-       "      <td>Jefferson County</td>\n",
-       "      <td>42.0</td>\n",
-       "      <td>65.0</td>\n",
-       "      <td>Violent crime rate</td>\n",
-       "      <td>43.0</td>\n",
-       "      <td>78.000000</td>\n",
-       "      <td>41713.33333</td>\n",
-       "      <td>186.990571</td>\n",
-       "      <td>42065.0</td>\n",
-       "      <td>2006.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>255665</th>\n",
-       "      <td>PA</td>\n",
-       "      <td>Jefferson County</td>\n",
-       "      <td>42.0</td>\n",
-       "      <td>65.0</td>\n",
-       "      <td>Violent crime rate</td>\n",
-       "      <td>43.0</td>\n",
-       "      <td>93.000000</td>\n",
-       "      <td>41800.33333</td>\n",
-       "      <td>222.486264</td>\n",
-       "      <td>42065.0</td>\n",
-       "      <td>2007.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>255666</th>\n",
-       "      <td>PA</td>\n",
-       "      <td>Jefferson County</td>\n",
-       "      <td>42.0</td>\n",
-       "      <td>65.0</td>\n",
-       "      <td>Violent crime rate</td>\n",
-       "      <td>43.0</td>\n",
-       "      <td>97.000000</td>\n",
-       "      <td>42344.00000</td>\n",
-       "      <td>229.076138</td>\n",
-       "      <td>42065.0</td>\n",
+       "      <td>73.666667</td>\n",
+       "      <td>41192.33333</td>\n",
+       "      <td>178.835868</td>\n",
+       "      <td>27067.0</td>\n",
        "      <td>2008.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>250766</th>\n",
+       "      <td>MO</td>\n",
+       "      <td>Linn County</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>115.0</td>\n",
+       "      <td>Violent crime rate</td>\n",
+       "      <td>43.0</td>\n",
+       "      <td>25.333333</td>\n",
+       "      <td>12588.33333</td>\n",
+       "      <td>201.244539</td>\n",
+       "      <td>29115.0</td>\n",
+       "      <td>2008.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>250769</th>\n",
+       "      <td>MO</td>\n",
+       "      <td>Livingston County</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>117.0</td>\n",
+       "      <td>Violent crime rate</td>\n",
+       "      <td>43.0</td>\n",
+       "      <td>29.333333</td>\n",
+       "      <td>14430.00000</td>\n",
+       "      <td>203.280203</td>\n",
+       "      <td>29117.0</td>\n",
+       "      <td>2004.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>250770</th>\n",
+       "      <td>MO</td>\n",
+       "      <td>Livingston County</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>117.0</td>\n",
+       "      <td>Violent crime rate</td>\n",
+       "      <td>43.0</td>\n",
+       "      <td>30.333333</td>\n",
+       "      <td>14343.66667</td>\n",
+       "      <td>211.475448</td>\n",
+       "      <td>29117.0</td>\n",
+       "      <td>2005.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>250771</th>\n",
+       "      <td>MO</td>\n",
+       "      <td>Livingston County</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>117.0</td>\n",
+       "      <td>Violent crime rate</td>\n",
+       "      <td>43.0</td>\n",
+       "      <td>27.000000</td>\n",
+       "      <td>14324.50000</td>\n",
+       "      <td>188.488254</td>\n",
+       "      <td>29117.0</td>\n",
+       "      <td>2006.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "       state              county  state_code  county_code        measure_name  \\\n",
-       "251382    MT  Musselshell County        30.0         65.0  Violent crime rate   \n",
-       "255671    PA      Juniata County        42.0         67.0  Violent crime rate   \n",
-       "255664    PA    Jefferson County        42.0         65.0  Violent crime rate   \n",
-       "255665    PA    Jefferson County        42.0         65.0  Violent crime rate   \n",
-       "255666    PA    Jefferson County        42.0         65.0  Violent crime rate   \n",
+       "       state             county  state_code  county_code        measure_name  \\\n",
+       "249671    MN   Kandiyohi County        27.0         67.0  Violent crime rate   \n",
+       "250766    MO        Linn County        29.0        115.0  Violent crime rate   \n",
+       "250769    MO  Livingston County        29.0        117.0  Violent crime rate   \n",
+       "250770    MO  Livingston County        29.0        117.0  Violent crime rate   \n",
+       "250771    MO  Livingston County        29.0        117.0  Violent crime rate   \n",
        "\n",
        "        measure_id  numerator  denominator   raw_value  fips_code  start_year  \n",
-       "251382        43.0  19.000000   4533.50000  419.102239    30065.0      2003.0  \n",
-       "255671        43.0  20.666667  23216.66667   89.016511    42067.0      2006.0  \n",
-       "255664        43.0  78.000000  41713.33333  186.990571    42065.0      2006.0  \n",
-       "255665        43.0  93.000000  41800.33333  222.486264    42065.0      2007.0  \n",
-       "255666        43.0  97.000000  42344.00000  229.076138    42065.0      2008.0  "
+       "249671        43.0  73.666667  41192.33333  178.835868    27067.0      2008.0  \n",
+       "250766        43.0  25.333333  12588.33333  201.244539    29115.0      2008.0  \n",
+       "250769        43.0  29.333333  14430.00000  203.280203    29117.0      2004.0  \n",
+       "250770        43.0  30.333333  14343.66667  211.475448    29117.0      2005.0  \n",
+       "250771        43.0  27.000000  14324.50000  188.488254    29117.0      2006.0  "
       ]
      },
-     "execution_count": 69,
+     "execution_count": 165,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1884,7 +2095,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 166,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(17180, 11)"
+      ]
+     },
+     "execution_count": 166,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df2[df2.measure_name=='Violent crime rate'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
    "metadata": {},
    "outputs": [
     {
@@ -1937,59 +2168,59 @@
        "      <td>1997.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24012</th>\n",
-       "      <td>OH</td>\n",
-       "      <td>Warren County</td>\n",
-       "      <td>39.0</td>\n",
-       "      <td>165.0</td>\n",
+       "      <th>24239</th>\n",
+       "      <td>OK</td>\n",
+       "      <td>Cimarron County</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>25.0</td>\n",
        "      <td>Premature Death</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1371.0</td>\n",
+       "      <td>55.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>6093.7</td>\n",
-       "      <td>39165.0</td>\n",
-       "      <td>1997.0</td>\n",
+       "      <td>13993.1</td>\n",
+       "      <td>40025.0</td>\n",
+       "      <td>2001.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24014</th>\n",
+       "      <th>24026</th>\n",
        "      <td>OH</td>\n",
-       "      <td>Warren County</td>\n",
+       "      <td>Washington County</td>\n",
        "      <td>39.0</td>\n",
-       "      <td>165.0</td>\n",
+       "      <td>167.0</td>\n",
        "      <td>Premature Death</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1469.0</td>\n",
+       "      <td>841.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>5777.2</td>\n",
-       "      <td>39165.0</td>\n",
+       "      <td>7449.7</td>\n",
+       "      <td>39167.0</td>\n",
        "      <td>1999.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24015</th>\n",
+       "      <th>24027</th>\n",
        "      <td>OH</td>\n",
-       "      <td>Warren County</td>\n",
+       "      <td>Washington County</td>\n",
        "      <td>39.0</td>\n",
-       "      <td>165.0</td>\n",
+       "      <td>167.0</td>\n",
        "      <td>Premature Death</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1466.0</td>\n",
+       "      <td>842.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>5534.9</td>\n",
-       "      <td>39165.0</td>\n",
+       "      <td>8243.5</td>\n",
+       "      <td>39167.0</td>\n",
        "      <td>2000.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24016</th>\n",
+       "      <th>24028</th>\n",
        "      <td>OH</td>\n",
-       "      <td>Warren County</td>\n",
+       "      <td>Washington County</td>\n",
        "      <td>39.0</td>\n",
-       "      <td>165.0</td>\n",
+       "      <td>167.0</td>\n",
        "      <td>Premature Death</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1494.0</td>\n",
+       "      <td>844.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>5618.1</td>\n",
-       "      <td>39165.0</td>\n",
+       "      <td>8355.2</td>\n",
+       "      <td>39167.0</td>\n",
        "      <td>2001.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1997,22 +2228,22 @@
        "</div>"
       ],
       "text/plain": [
-       "      state         county  state_code  county_code     measure_name  \\\n",
-       "5        AL   Henry County         1.0         67.0  Premature Death   \n",
-       "24012    OH  Warren County        39.0        165.0  Premature Death   \n",
-       "24014    OH  Warren County        39.0        165.0  Premature Death   \n",
-       "24015    OH  Warren County        39.0        165.0  Premature Death   \n",
-       "24016    OH  Warren County        39.0        165.0  Premature Death   \n",
+       "      state             county  state_code  county_code     measure_name  \\\n",
+       "5        AL       Henry County         1.0         67.0  Premature Death   \n",
+       "24239    OK    Cimarron County        40.0         25.0  Premature Death   \n",
+       "24026    OH  Washington County        39.0        167.0  Premature Death   \n",
+       "24027    OH  Washington County        39.0        167.0  Premature Death   \n",
+       "24028    OH  Washington County        39.0        167.0  Premature Death   \n",
        "\n",
        "       measure_id  numerator  denominator  raw_value  fips_code  start_year  \n",
        "5             1.0      251.0          NaN    10920.2     1067.0      1997.0  \n",
-       "24012         1.0     1371.0          NaN     6093.7    39165.0      1997.0  \n",
-       "24014         1.0     1469.0          NaN     5777.2    39165.0      1999.0  \n",
-       "24015         1.0     1466.0          NaN     5534.9    39165.0      2000.0  \n",
-       "24016         1.0     1494.0          NaN     5618.1    39165.0      2001.0  "
+       "24239         1.0       55.0          NaN    13993.1    40025.0      2001.0  \n",
+       "24026         1.0      841.0          NaN     7449.7    39167.0      1999.0  \n",
+       "24027         1.0      842.0          NaN     8243.5    39167.0      2000.0  \n",
+       "24028         1.0      844.0          NaN     8355.2    39167.0      2001.0  "
       ]
      },
-     "execution_count": 70,
+     "execution_count": 167,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2025,7 +2256,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 168,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(14369, 11)"
+      ]
+     },
+     "execution_count": 168,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df3[df3.measure_name=='Premature Death'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
    "metadata": {},
    "outputs": [
     {
@@ -2064,45 +2315,31 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>35738</th>\n",
+       "      <th>35749</th>\n",
        "      <td>AL</td>\n",
-       "      <td>Alabama</td>\n",
+       "      <td>Autauga County</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>Unemployment</td>\n",
        "      <td>23.0</td>\n",
-       "      <td>157119.0</td>\n",
-       "      <td>2156304.0</td>\n",
-       "      <td>0.072865</td>\n",
-       "      <td>1000.0</td>\n",
+       "      <td>1644.0</td>\n",
+       "      <td>25480.0</td>\n",
+       "      <td>0.064521</td>\n",
+       "      <td>1001.0</td>\n",
        "      <td>2012.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>59716</th>\n",
+       "      <th>59727</th>\n",
        "      <td>OK</td>\n",
-       "      <td>Dewey County</td>\n",
+       "      <td>Ellis County</td>\n",
        "      <td>40.0</td>\n",
-       "      <td>43.0</td>\n",
+       "      <td>45.0</td>\n",
        "      <td>Unemployment</td>\n",
        "      <td>23.0</td>\n",
-       "      <td>76.0</td>\n",
-       "      <td>2903.0</td>\n",
-       "      <td>0.026180</td>\n",
-       "      <td>40043.0</td>\n",
-       "      <td>2012.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>59606</th>\n",
-       "      <td>OK</td>\n",
-       "      <td>Choctaw County</td>\n",
-       "      <td>40.0</td>\n",
-       "      <td>23.0</td>\n",
-       "      <td>Unemployment</td>\n",
-       "      <td>23.0</td>\n",
-       "      <td>468.0</td>\n",
-       "      <td>7038.0</td>\n",
-       "      <td>0.066496</td>\n",
-       "      <td>40023.0</td>\n",
+       "      <td>63.0</td>\n",
+       "      <td>2791.0</td>\n",
+       "      <td>0.022573</td>\n",
+       "      <td>40045.0</td>\n",
        "      <td>2012.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -2133,36 +2370,77 @@
        "      <td>40027.0</td>\n",
        "      <td>2012.0</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>59639</th>\n",
+       "      <td>OK</td>\n",
+       "      <td>Coal County</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>Unemployment</td>\n",
+       "      <td>23.0</td>\n",
+       "      <td>162.0</td>\n",
+       "      <td>2747.0</td>\n",
+       "      <td>0.058973</td>\n",
+       "      <td>40029.0</td>\n",
+       "      <td>2012.0</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "      state            county  state_code  county_code  measure_name  \\\n",
-       "35738    AL           Alabama         1.0          0.0  Unemployment   \n",
-       "59716    OK      Dewey County        40.0         43.0  Unemployment   \n",
-       "59606    OK    Choctaw County        40.0         23.0  Unemployment   \n",
+       "35749    AL    Autauga County         1.0          1.0  Unemployment   \n",
+       "59727    OK      Ellis County        40.0         45.0  Unemployment   \n",
        "59617    OK   Cimarron County        40.0         25.0  Unemployment   \n",
        "59628    OK  Cleveland County        40.0         27.0  Unemployment   \n",
+       "59639    OK       Coal County        40.0         29.0  Unemployment   \n",
        "\n",
        "       measure_id  numerator  denominator  raw_value  fips_code  start_year  \n",
-       "35738        23.0   157119.0    2156304.0   0.072865     1000.0      2012.0  \n",
-       "59716        23.0       76.0       2903.0   0.026180    40043.0      2012.0  \n",
-       "59606        23.0      468.0       7038.0   0.066496    40023.0      2012.0  \n",
+       "35749        23.0     1644.0      25480.0   0.064521     1001.0      2012.0  \n",
+       "59727        23.0       63.0       2791.0   0.022573    40045.0      2012.0  \n",
        "59617        23.0       41.0       1139.0   0.035996    40025.0      2012.0  \n",
-       "59628        23.0     5653.0     128843.0   0.043875    40027.0      2012.0  "
+       "59628        23.0     5653.0     128843.0   0.043875    40027.0      2012.0  \n",
+       "59639        23.0      162.0       2747.0   0.058973    40029.0      2012.0  "
       ]
      },
-     "execution_count": 71,
+     "execution_count": 169,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# top five measures with the higest raw_value in group 4\n",
+    "# Top five measures with the higest raw_value in group 4\n",
     "\n",
     "df4.sort_values(by='measure_name', ascending=False).head()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3218, 11)"
+      ]
+     },
+     "execution_count": 171,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df4[df4.measure_name=='Unemployment'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
I deleted records with county_code=0 based on Fred's discovery.   This has reduced the number of records as expected.  Below is an updated list of the number of records for each year.  

2008.0    37024
2009.0    34033
2010.0    31092
2006.0    29991
2007.0    24775
2004.0    21557
2005.0    21546
2011.0    21445
2003.0    21133
2002.0     9145
2012.0     3218
1997.0     2884
1998.0     2879
2001.0     2870
2000.0     2868
1999.0     2868

Deletion of the records didn't change the patterns of raw_value distribution in the four year-groups,
    group 1 : 2009, 2010, 2011.  It has a total of 86570 records.
    group 2: 2008,2007,2006,2004,2005,2003,2002.  It has a total of 165171 records.
    group 3: 1997,1998,1999,2001,2000.  It has a total of 14369 records.
    group 4 has only one year: 2012.   It has a total of 3218 records.

Just realized that the subtitles in the summary cells are misleading, will change them in the next round.